### PR TITLE
BigDecimal methods for isWhole and roundToBigInteger

### DIFF
--- a/kotlin-utils/build.gradle.kts
+++ b/kotlin-utils/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 }
 
 group = "xyz.lbres"
-version = "1.3.2"
+version = "1.3.3"
 
 repositories {
     mavenCentral()

--- a/kotlin-utils/src/main/kotlin/xyz/lbres/kotlinutils/bigdecimal/ext/BigDecimalExt.kt
+++ b/kotlin-utils/src/main/kotlin/xyz/lbres/kotlinutils/bigdecimal/ext/BigDecimalExt.kt
@@ -1,8 +1,11 @@
 package xyz.lbres.kotlinutils.bigdecimal.ext
 
 import xyz.lbres.kotlinutils.biginteger.ext.isZero
+import xyz.lbres.kotlinutils.general.succeeds
 import xyz.lbres.kotlinutils.general.tryOrDefault
 import java.math.BigDecimal
+import java.math.BigInteger
+import java.math.RoundingMode
 
 /**
  * Unary check to determine if value is zero
@@ -17,3 +20,20 @@ fun BigDecimal.isZero(): Boolean = tryOrDefault(false) { toBigIntegerExact().isZ
  * @return [Boolean]: true if value is less than zero, false otherwise
  */
 fun BigDecimal.isNegative(): Boolean = this < BigDecimal.ZERO
+
+/**
+ * Determine if value is a whole number
+ *
+ * @return `true` if number is a whole number, `false` otherwise
+ */
+fun BigDecimal.isWholeNumber(): Boolean = succeeds { toBigIntegerExact() }
+
+/**
+ * Round to the nearest whole number using the provided rounding mode
+ *
+ * @param roundingMode [RoundingMode]: mode to use when rounding. Defaults to [RoundingMode.HALF_UP]
+ * @return [BigInteger]: closest whole number by the specified mode
+ */
+fun BigDecimal.roundToBigInteger(roundingMode: RoundingMode = RoundingMode.HALF_UP): BigInteger {
+    return setScale(0, roundingMode).toBigInteger()
+}

--- a/kotlin-utils/src/test/kotlin/xyz/lbres/kotlinutils/bigdecimal/ext/BigDecimalExtTest.kt
+++ b/kotlin-utils/src/test/kotlin/xyz/lbres/kotlinutils/bigdecimal/ext/BigDecimalExtTest.kt
@@ -113,7 +113,7 @@ class BigDecimalExtTest {
         expected = BigInteger.ONE
         assertEquals(expected, bd.roundToBigInteger())
 
-        bd = BigDecimal("-0.3333333333333333333333333333")
+        bd = BigDecimal("-0.4555555555555555555555555555")
         expected = BigInteger.ZERO
         assertEquals(expected, bd.roundToBigInteger())
 
@@ -126,7 +126,7 @@ class BigDecimalExtTest {
         assertEquals(expected, bd.roundToBigInteger())
 
         // down
-        bd = BigDecimal("0.45")
+        bd = BigDecimal("0.4555555555555555555555555555")
         expected = BigInteger.ZERO
         assertEquals(expected, bd.roundToBigInteger())
 
@@ -147,9 +147,9 @@ class BigDecimalExtTest {
         expected = BigInteger.ONE
         assertEquals(expected, bd.roundToBigInteger(RoundingMode.UP))
 
-        bd = BigDecimal("7.5")
-        expected = BigInteger("7")
-        assertEquals(expected, bd.roundToBigInteger(RoundingMode.HALF_DOWN))
+        bd = BigDecimal("6.5")
+        expected = BigInteger("6")
+        assertEquals(expected, bd.roundToBigInteger(RoundingMode.HALF_EVEN))
 
         bd = BigDecimal("9.99999999999999")
         expected = BigInteger("9")

--- a/kotlin-utils/src/test/kotlin/xyz/lbres/kotlinutils/bigdecimal/ext/BigDecimalExtTest.kt
+++ b/kotlin-utils/src/test/kotlin/xyz/lbres/kotlinutils/bigdecimal/ext/BigDecimalExtTest.kt
@@ -104,7 +104,7 @@ class BigDecimalExtTest {
         var expected = BigInteger("1000000000000000000000")
         assertEquals(expected, bd.roundToBigInteger())
 
-        bd = BigDecimal("-123")
+        bd = BigDecimal("-123.000000000000000000000000000")
         expected = BigInteger("-123")
         assertEquals(expected, bd.roundToBigInteger())
 
@@ -121,7 +121,7 @@ class BigDecimalExtTest {
         expected = BigInteger("12346")
         assertEquals(expected, bd.roundToBigInteger())
 
-        bd = BigDecimal("-12.2")
+        bd = BigDecimal("-12.2000000000000000000045679")
         expected = BigInteger("-12")
         assertEquals(expected, bd.roundToBigInteger())
 
@@ -138,7 +138,7 @@ class BigDecimalExtTest {
         expected = BigInteger("-12346")
         assertEquals(expected, bd.roundToBigInteger())
 
-        bd = BigDecimal("12.2")
+        bd = BigDecimal("12.2000000000000000000045679")
         expected = BigInteger("12")
         assertEquals(expected, bd.roundToBigInteger())
 

--- a/kotlin-utils/src/test/kotlin/xyz/lbres/kotlinutils/bigdecimal/ext/BigDecimalExtTest.kt
+++ b/kotlin-utils/src/test/kotlin/xyz/lbres/kotlinutils/bigdecimal/ext/BigDecimalExtTest.kt
@@ -1,7 +1,10 @@
 package xyz.lbres.kotlinutils.bigdecimal.ext
 
 import java.math.BigDecimal
+import java.math.BigInteger
+import java.math.RoundingMode
 import kotlin.test.Test
+import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
@@ -54,5 +57,102 @@ class BigDecimalExtTest {
 
         bd = BigDecimal("1231.4252435")
         assertFalse(bd.isNegative())
+    }
+
+    @Test
+    fun testIsWholeNumber() {
+        // whole number
+        var bd = BigDecimal.ZERO
+        assertTrue(bd.isWholeNumber())
+
+        bd = BigDecimal("100")
+        assertTrue(bd.isWholeNumber())
+
+        bd = BigDecimal("-100")
+        assertTrue(bd.isWholeNumber())
+
+        bd = BigDecimal("-1234560000000000000999")
+        assertTrue(bd.isWholeNumber())
+
+        bd = BigDecimal("123456000000000.0000")
+        assertTrue(bd.isWholeNumber())
+
+        bd = BigDecimal("7.00000000000000000000000000000")
+        assertTrue(bd.isWholeNumber())
+
+        // decimal
+        bd = BigDecimal("0.00000000000000000001")
+        assertFalse(bd.isWholeNumber())
+
+        bd = BigDecimal("-1.01")
+        assertFalse(bd.isWholeNumber())
+
+        bd = BigDecimal("123456000000000000099.9")
+        assertFalse(bd.isWholeNumber())
+
+        bd = BigDecimal("99999999999999999999999.9")
+        assertFalse(bd.isWholeNumber())
+    }
+
+    @Test
+    fun testRoundToBigInteger() {
+        // whole
+        assertEquals(BigInteger.ZERO, BigDecimal.ZERO.roundToBigInteger())
+        assertEquals(BigInteger.ONE, BigDecimal.ONE.roundToBigInteger())
+
+        var bd = BigDecimal("1000000000000000000000")
+        var expected = BigInteger("1000000000000000000000")
+        assertEquals(expected, bd.roundToBigInteger())
+
+        bd = BigDecimal("-123")
+        expected = BigInteger("-123")
+        assertEquals(expected, bd.roundToBigInteger())
+
+        // up
+        bd = BigDecimal("0.5")
+        expected = BigInteger.ONE
+        assertEquals(expected, bd.roundToBigInteger())
+
+        bd = BigDecimal("-0.3333333333333333333333333333")
+        expected = BigInteger.ZERO
+        assertEquals(expected, bd.roundToBigInteger())
+
+        bd = BigDecimal("12345.67")
+        expected = BigInteger("12346")
+        assertEquals(expected, bd.roundToBigInteger())
+
+        bd = BigDecimal("-12.2")
+        expected = BigInteger("-12")
+        assertEquals(expected, bd.roundToBigInteger())
+
+        // down
+        bd = BigDecimal("0.45")
+        expected = BigInteger.ZERO
+        assertEquals(expected, bd.roundToBigInteger())
+
+        bd = BigDecimal("-0.5")
+        expected = -BigInteger.ONE
+        assertEquals(expected, bd.roundToBigInteger())
+
+        bd = BigDecimal("-12345.67")
+        expected = BigInteger("-12346")
+        assertEquals(expected, bd.roundToBigInteger())
+
+        bd = BigDecimal("12.2")
+        expected = BigInteger("12")
+        assertEquals(expected, bd.roundToBigInteger())
+
+        // other rounding modes
+        bd = BigDecimal("0.333")
+        expected = BigInteger.ONE
+        assertEquals(expected, bd.roundToBigInteger(RoundingMode.UP))
+
+        bd = BigDecimal("7.5")
+        expected = BigInteger("7")
+        assertEquals(expected, bd.roundToBigInteger(RoundingMode.HALF_DOWN))
+
+        bd = BigDecimal("9.99999999999999")
+        expected = BigInteger("9")
+        assertEquals(expected, bd.roundToBigInteger(RoundingMode.DOWN))
     }
 }


### PR DESCRIPTION
## What was changed?
- Add BigDecimal extension methods for isWhole and roundToBigInteger

## Checks
- [x] New and existing unit tests pass with my changes
- [x] Unit tests have been written for all new and changed functions
- [x] Comments have been added where needed
- [x] Docstrings have been updated with any modified function signatures
- [x] ktlint has run successfully
- [x] The version number has been updated if necessary

## How was this tested?
Unit tests