### PR TITLE
Shift ConstMultiSet code to impl classes

### DIFF
--- a/kotlin-utils/src/main/kotlin/xyz/lbres/kotlinutils/set/multiset/const/ConstMultiSet.kt
+++ b/kotlin-utils/src/main/kotlin/xyz/lbres/kotlinutils/set/multiset/const/ConstMultiSet.kt
@@ -125,7 +125,7 @@ sealed class ConstMultiSet<E> constructor(private val initialElements: Collectio
      * @param other [ConstMultiSet]<E>: values to add to this set
      * @return [ConstMultiSet]<E>: ConstMultiSet containing all values from both sets
      */
-    fun plusC(other: ConstMultiSet<E>): ConstMultiSet<E> {
+    open fun plusC(other: ConstMultiSet<E>): ConstMultiSet<E> {
         val newCounts = combineCounts(other, Int::plus, true)
         return ConstMultiSetImpl(countsToList(newCounts), newCounts)
     }
@@ -136,7 +136,7 @@ sealed class ConstMultiSet<E> constructor(private val initialElements: Collectio
      * @param other [ConstMultiSet]<E>: values to subtract from this set
      * @return [ConstMultiSet]<E>: ConstMultiSet containing the items in this set but not the other
      */
-    fun minusC(other: ConstMultiSet<E>): ConstMultiSet<E> {
+    open fun minusC(other: ConstMultiSet<E>): ConstMultiSet<E> {
         val newCounts = combineCounts(other, Int::minus, false)
         return ConstMultiSetImpl(countsToList(newCounts), newCounts)
     }
@@ -147,7 +147,7 @@ sealed class ConstMultiSet<E> constructor(private val initialElements: Collectio
      * @param other [ConstMultiSet]<E>: ConstMultiSet to intersect with current
      * @return [ConstMultiSet]<E>: ConstMultiSet containing only values that are in both sets
      */
-    infix fun intersectC(other: ConstMultiSet<E>): ConstMultiSet<E> {
+    open infix fun intersectC(other: ConstMultiSet<E>): ConstMultiSet<E> {
         val newCounts = combineCounts(other, { val1, val2 -> min(val1, val2) }, false)
         return ConstMultiSetImpl(countsToList(newCounts), newCounts)
     }

--- a/kotlin-utils/src/main/kotlin/xyz/lbres/kotlinutils/set/multiset/const/ConstMultiSet.kt
+++ b/kotlin-utils/src/main/kotlin/xyz/lbres/kotlinutils/set/multiset/const/ConstMultiSet.kt
@@ -15,104 +15,6 @@ import kotlin.math.min
  * Behavior is not defined if values of elements are changed (i.e. elements are added to a mutable list).
  */
 sealed class ConstMultiSet<E> constructor(private val initialElements: Collection<E>, private var initialCounts: Map<E, Int>? = null) : MultiSet<E> {
-    /**
-     * Number of elements in set.
-     */
-    // TODO private
-    protected var _size: Int = initialElements.size
-    override val size: Int
-        get() = _size
-
-    /**
-     * Map where each key is an element in the set, and each value is the number of occurrences of the element in the set.
-     * Counts are guaranteed to be greater than 0.
-     */
-    protected open val counts: Map<E, Int> = initializeCounts()
-
-    /**
-     * All distinct values contained in the set.
-     */
-    override val distinctValues: Set<E> = (initialCounts ?: initializeCounts()).keys
-
-    /**
-     * String representation of the set
-     */
-    protected open val string: String = countsToString(initialCounts ?: initializeCounts())
-
-    /**
-     * All elements in the set
-     */
-    protected open val elements: Collection<E> = initialElements
-
-    /**
-     * Get the number of occurrences of a given element.
-     *
-     * @param element [E]
-     * @return [Int]: the number of occurrences of [element]. 0 if the element does not exist.
-     */
-    override fun getCountOf(element: E): Int = counts.getOrDefault(element, 0)
-
-    /**
-     * Determine if an element is contained in the current set.
-     *
-     * @param element [E]
-     * @return [Boolean]: `true` if [element] is in the set, `false` otherwise
-     */
-    override fun contains(element: E): Boolean = counts.contains(element)
-
-    /**
-     * Determine if all elements in a collection are contained in the current set.
-     * If the collection contains multiple occurrences of the same value, the function will check if this set contains at least as many occurrences as the collection.
-     *
-     * @param elements [Collection]<E>
-     * @return [Boolean]: `true` if the current set contains at least as many occurrences of each value as the collection, `false` otherwise
-     */
-    override fun containsAll(elements: Collection<E>): Boolean {
-        val otherCounts = createCountsMap(elements)
-
-        return otherCounts.all { (element, otherCount) ->
-            otherCount <= getCountOf(element)
-        }
-    }
-
-    /**
-     * Create a new MultiSet with all values from both sets.
-     * If there are multiple occurrences of a value, the number of occurrences in the other set will be added to the number in this set.
-     * The returned set is **not** a ConstMultiSet.
-     *
-     * @param other [MultiSet]<E>: values to add to this set
-     * @return [MultiSet]<E>: MultiSet containing all values from both sets
-     */
-    override operator fun plus(other: MultiSet<E>): MultiSet<E> {
-        val newCounts = combineCounts(other, Int::plus, true)
-        return MultiSetImpl(countsToList(newCounts))
-    }
-
-    /**
-     * Create a new MultiSet with values that are in this set but not the other set.
-     * If there are multiple occurrences of a value, the number of occurrences in the other set will be subtracted from the number in this set.
-     * The returned set is **not** a ConstMultiSet.
-     *
-     * @param other [MultiSet]<E>: values to subtract from this set
-     * @return [MultiSet]<E>: MultiSet containing the items in this set but not the other
-     */
-    override operator fun minus(other: MultiSet<E>): MultiSet<E> {
-        val newCounts = combineCounts(other, Int::minus, false)
-        return MultiSetImpl(countsToList(newCounts))
-    }
-
-    /**
-     * Create a new MultiSet with values that are shared between the sets.
-     * If there are multiple occurrences of a value, the smaller number of occurrences will be used.
-     * The returned set is **not** a ConstMultiSet.
-     *
-     * @param other [MultiSet]<E>: MultiSet to intersect with current
-     * @return [MultiSet]<E>: MultiSet containing only values that are in both sets
-     */
-    override infix fun intersect(other: MultiSet<E>): MultiSet<E> {
-        val newCounts = combineCounts(other, { val1, val2 -> min(val1, val2) }, false)
-        return MultiSetImpl(countsToList(newCounts))
-    }
 
     @Suppress(Suppressions.FUNCTION_NAME)
     infix fun `+c`(other: ConstMultiSet<E>): ConstMultiSet<E> = plusC(other)
@@ -125,10 +27,7 @@ sealed class ConstMultiSet<E> constructor(private val initialElements: Collectio
      * @param other [ConstMultiSet]<E>: values to add to this set
      * @return [ConstMultiSet]<E>: ConstMultiSet containing all values from both sets
      */
-    open fun plusC(other: ConstMultiSet<E>): ConstMultiSet<E> {
-        val newCounts = combineCounts(other, Int::plus, true)
-        return ConstMultiSetImpl(countsToList(newCounts), newCounts)
-    }
+    abstract fun plusC(other: ConstMultiSet<E>): ConstMultiSet<E>
 
     /**
      * Alternate version of [minus], which returns a ConstMultiSet
@@ -136,10 +35,7 @@ sealed class ConstMultiSet<E> constructor(private val initialElements: Collectio
      * @param other [ConstMultiSet]<E>: values to subtract from this set
      * @return [ConstMultiSet]<E>: ConstMultiSet containing the items in this set but not the other
      */
-    open fun minusC(other: ConstMultiSet<E>): ConstMultiSet<E> {
-        val newCounts = combineCounts(other, Int::minus, false)
-        return ConstMultiSetImpl(countsToList(newCounts), newCounts)
-    }
+    abstract fun minusC(other: ConstMultiSet<E>): ConstMultiSet<E>
 
     /**
      * Alternate version of [intersect], which returns a ConstMultiSet
@@ -147,32 +43,7 @@ sealed class ConstMultiSet<E> constructor(private val initialElements: Collectio
      * @param other [ConstMultiSet]<E>: ConstMultiSet to intersect with current
      * @return [ConstMultiSet]<E>: ConstMultiSet containing only values that are in both sets
      */
-    open infix fun intersectC(other: ConstMultiSet<E>): ConstMultiSet<E> {
-        val newCounts = combineCounts(other, { val1, val2 -> min(val1, val2) }, false)
-        return ConstMultiSetImpl(countsToList(newCounts), newCounts)
-    }
-
-    /**
-     * Combine counts with another MultiSet, using the given operation
-     *
-     * @param other [MultiSet]<E>: MultiSet to combine with
-     * @param operation (Int, Int) -> Int: combination function
-     * @param useAllValues [Boolean]: if all values from both sets should be used to generate the new set. If `false`, only the values from this set will be used.
-     * @return [Map]<E, Int>: new counts map where each element has the number of occurrences specified by the operation
-     */
-    private fun combineCounts(other: MultiSet<E>, operation: (count: Int, otherCount: Int) -> Int, useAllValues: Boolean): Map<E, Int> {
-        val values = simpleIf(useAllValues, { distinctValues + other.distinctValues }, { distinctValues })
-        return values.associateWith {
-            operation(getCountOf(it), other.getCountOf(it))
-        }.filter { it.value > 0 }
-    }
-
-    /**
-     * If the current set contains 0 elements.
-     *
-     * @return [Boolean]: `true` if the set contains 0 elements, `false` otherwise
-     */
-    override fun isEmpty(): Boolean = size == 0
+    abstract infix fun intersectC(other: ConstMultiSet<E>): ConstMultiSet<E>
 
     /**
      * If the current set contains the same elements as another MultiSet, with the same number of occurrences per element.
@@ -187,50 +58,15 @@ sealed class ConstMultiSet<E> constructor(private val initialElements: Collectio
 
         @Suppress(Suppressions.UNCHECKED_CAST)
         return tryOrDefault(false, listOf(ClassCastException::class)) {
-            if (other is ConstMultiSet<*>) {
-                other as ConstMultiSet<E>
-                counts == other.counts
-            } else {
-                other as MultiSet<E>
-                size == other.size && distinctValues.all { getCountOf(it) == other.getCountOf(it) }
-            }
+            other as MultiSet<E>
+            size == other.size && distinctValues.all { getCountOf(it) == other.getCountOf(it) }
+//            if (other is ConstMultiSet<*>) {
+//                other as ConstMultiSet<E>
+//                counts == other.counts
+//            } else {
+//                other as MultiSet<E>
+//                size == other.size && distinctValues.all { getCountOf(it) == other.getCountOf(it) }
+//            }
         }
-    }
-
-    /**
-     * Get a string representation of the set.
-     *
-     * @return [String]
-     */
-    override fun toString(): String = string
-
-    /**
-     * Get an iterator for the elements in this set.
-     *
-     * @return [Iterator]<E>
-     */
-    override fun iterator(): Iterator<E> = elements.iterator()
-
-    /**
-     * Get hash code for set.
-     *
-     * @return [Int]
-     */
-    override fun hashCode(): Int {
-        val hashCode = counts.hashCode()
-        return 31 * hashCode + MultiSet::class.java.name.hashCode()
-    }
-
-    /**
-     * Generate a counts map from the initial elements
-     *
-     * @return [Map]<E, Int>: generated map
-     */
-    protected fun initializeCounts(): Map<E, Int> {
-        if (initialCounts == null) {
-            initialCounts = createCountsMap(initialElements)
-        }
-
-        return initialCounts!!
     }
 }

--- a/kotlin-utils/src/main/kotlin/xyz/lbres/kotlinutils/set/multiset/const/ConstMultiSet.kt
+++ b/kotlin-utils/src/main/kotlin/xyz/lbres/kotlinutils/set/multiset/const/ConstMultiSet.kt
@@ -1,14 +1,8 @@
 package xyz.lbres.kotlinutils.set.multiset.const
 
-import xyz.lbres.kotlinutils.general.simpleIf
 import xyz.lbres.kotlinutils.general.tryOrDefault
 import xyz.lbres.kotlinutils.internal.constants.Suppressions
 import xyz.lbres.kotlinutils.set.multiset.MultiSet
-import xyz.lbres.kotlinutils.set.multiset.impl.MultiSetImpl
-import xyz.lbres.kotlinutils.set.multiset.utils.countsToList
-import xyz.lbres.kotlinutils.set.multiset.utils.countsToString
-import xyz.lbres.kotlinutils.set.multiset.utils.createCountsMap
-import kotlin.math.min
 
 /**
  * [MultiSet] implementation where values of elements are assumed to be constant.
@@ -52,10 +46,6 @@ sealed class ConstMultiSet<E> constructor(private val initialElements: Collectio
      * @return [Boolean]: `true` if [other] is a non-null MultiSet which contains the same values as the current set, `false` otherwise
      */
     override fun equals(other: Any?): Boolean {
-        if (other == null || other !is MultiSet<*>) {
-            return false
-        }
-
         @Suppress(Suppressions.UNCHECKED_CAST)
         return tryOrDefault(false, listOf(ClassCastException::class)) {
             other as MultiSet<E>

--- a/kotlin-utils/src/main/kotlin/xyz/lbres/kotlinutils/set/multiset/const/ConstMultiSet.kt
+++ b/kotlin-utils/src/main/kotlin/xyz/lbres/kotlinutils/set/multiset/const/ConstMultiSet.kt
@@ -1,6 +1,5 @@
 package xyz.lbres.kotlinutils.set.multiset.const
 
-import xyz.lbres.kotlinutils.general.tryOrDefault
 import xyz.lbres.kotlinutils.internal.constants.Suppressions
 import xyz.lbres.kotlinutils.set.multiset.MultiSet
 
@@ -38,25 +37,4 @@ sealed class ConstMultiSet<E> constructor(private val initialElements: Collectio
      * @return [ConstMultiSet]<E>: ConstMultiSet containing only values that are in both sets
      */
     abstract infix fun intersectC(other: ConstMultiSet<E>): ConstMultiSet<E>
-
-    /**
-     * If the current set contains the same elements as another MultiSet, with the same number of occurrences per element.
-     *
-     * @param other [Any]?
-     * @return [Boolean]: `true` if [other] is a non-null MultiSet which contains the same values as the current set, `false` otherwise
-     */
-    override fun equals(other: Any?): Boolean {
-        @Suppress(Suppressions.UNCHECKED_CAST)
-        return tryOrDefault(false, listOf(ClassCastException::class)) {
-            other as MultiSet<E>
-            size == other.size && distinctValues.all { getCountOf(it) == other.getCountOf(it) }
-//            if (other is ConstMultiSet<*>) {
-//                other as ConstMultiSet<E>
-//                counts == other.counts
-//            } else {
-//                other as MultiSet<E>
-//                size == other.size && distinctValues.all { getCountOf(it) == other.getCountOf(it) }
-//            }
-        }
-    }
 }

--- a/kotlin-utils/src/main/kotlin/xyz/lbres/kotlinutils/set/multiset/const/ConstMultiSetImpl.kt
+++ b/kotlin-utils/src/main/kotlin/xyz/lbres/kotlinutils/set/multiset/const/ConstMultiSetImpl.kt
@@ -6,17 +6,17 @@ import xyz.lbres.kotlinutils.set.multiset.utils.countsToString
 import xyz.lbres.kotlinutils.set.multiset.utils.createCountsMap
 
 // final implementation of ConstMultiSet
-internal class ConstMultiSetImpl<E>(initialElements: Collection<E>, initialCounts: Map<E, Int>? = null) : ConstMultiSet<E>(initialElements, initialCounts) {
+internal class ConstMultiSetImpl<E>(private val elements: Collection<E>, initialCounts: Map<E, Int>? = null) : ConstMultiSet<E>(elements, initialCounts) {
     private val manager: ConstMultiSetManager<E>
-    override val size: Int = initialElements.size
+    override val size: Int = elements.size
     override val distinctValues: Set<E>
     private val string: String
     val counts: Map<E, Int>
 
     init {
-        counts = initialCounts.ifNull { createCountsMap(initialElements) }
+        counts = initialCounts.ifNull { createCountsMap(elements) }
         distinctValues = counts.keys
-        manager = ConstMultiSetManager(initialElements, counts)
+        manager = ConstMultiSetManager(counts)
         string = countsToString(counts)
     }
 
@@ -33,7 +33,7 @@ internal class ConstMultiSetImpl<E>(initialElements: Collection<E>, initialCount
     override fun intersectC(other: ConstMultiSet<E>): ConstMultiSet<E> = manager.intersectC(other)
 
     override fun isEmpty(): Boolean = manager.isEmpty()
-    override fun iterator(): Iterator<E> = manager.getIterator()
+    override fun iterator(): Iterator<E> = elements.iterator()
     override fun hashCode(): Int = manager.getHashCode()
     override fun equals(other: Any?): Boolean = manager.equalsSet(other)
     override fun toString(): String = string

--- a/kotlin-utils/src/main/kotlin/xyz/lbres/kotlinutils/set/multiset/const/ConstMultiSetImpl.kt
+++ b/kotlin-utils/src/main/kotlin/xyz/lbres/kotlinutils/set/multiset/const/ConstMultiSetImpl.kt
@@ -1,4 +1,36 @@
 package xyz.lbres.kotlinutils.set.multiset.const
 
+import xyz.lbres.kotlinutils.generic.ext.ifNull
+import xyz.lbres.kotlinutils.set.multiset.MultiSet
+import xyz.lbres.kotlinutils.set.multiset.utils.countsToString
+import xyz.lbres.kotlinutils.set.multiset.utils.createCountsMap
+
 // final implementation of ConstMultiSet
-internal class ConstMultiSetImpl<E>(initialElements: Collection<E>, initialCounts: Map<E, Int>? = null) : ConstMultiSet<E>(initialElements, initialCounts)
+internal class ConstMultiSetImpl<E>(initialElements: Collection<E>, initialCounts: Map<E, Int>? = null) : ConstMultiSet<E>(initialElements, initialCounts) {
+    private val manager: ConstMultiSetManager<E>
+    override val size: Int = initialElements.size
+    override val counts: Map<E, Int>
+    override val string: String
+
+    init {
+        counts = initialCounts.ifNull { createCountsMap(initialElements) }
+        manager = ConstMultiSetManager(initialElements, counts)
+        string = countsToString(counts)
+    }
+
+    override fun getCountOf(element: E): Int = manager.getCountOf(element)
+    override fun contains(element: E): Boolean = manager.contains(element)
+    override fun containsAll(elements: Collection<E>): Boolean = manager.containsAll(elements)
+
+    override fun plus(other: MultiSet<E>): MultiSet<E> = manager.plus(other)
+    override fun minus(other: MultiSet<E>): MultiSet<E> = manager.minus(other)
+    override fun intersect(other: MultiSet<E>): MultiSet<E> = manager.intersect(other)
+
+    override fun plusC(other: ConstMultiSet<E>): ConstMultiSet<E> = manager.plusC(other)
+    override fun minusC(other: ConstMultiSet<E>): ConstMultiSet<E> = manager.minusC(other)
+    override fun intersectC(other: ConstMultiSet<E>): ConstMultiSet<E> = manager.intersectC(other)
+
+    override fun isEmpty(): Boolean = manager.isEmpty()
+    override fun iterator(): Iterator<E> = manager.getIterator()
+    override fun hashCode(): Int = manager.getHashCode()
+}

--- a/kotlin-utils/src/main/kotlin/xyz/lbres/kotlinutils/set/multiset/const/ConstMultiSetImpl.kt
+++ b/kotlin-utils/src/main/kotlin/xyz/lbres/kotlinutils/set/multiset/const/ConstMultiSetImpl.kt
@@ -9,11 +9,13 @@ import xyz.lbres.kotlinutils.set.multiset.utils.createCountsMap
 internal class ConstMultiSetImpl<E>(initialElements: Collection<E>, initialCounts: Map<E, Int>? = null) : ConstMultiSet<E>(initialElements, initialCounts) {
     private val manager: ConstMultiSetManager<E>
     override val size: Int = initialElements.size
-    override val counts: Map<E, Int>
-    override val string: String
+    override val distinctValues: Set<E>
+    private val counts: Map<E, Int>
+    private val string: String
 
     init {
         counts = initialCounts.ifNull { createCountsMap(initialElements) }
+        distinctValues = counts.keys
         manager = ConstMultiSetManager(initialElements, counts)
         string = countsToString(counts)
     }
@@ -33,4 +35,5 @@ internal class ConstMultiSetImpl<E>(initialElements: Collection<E>, initialCount
     override fun isEmpty(): Boolean = manager.isEmpty()
     override fun iterator(): Iterator<E> = manager.getIterator()
     override fun hashCode(): Int = manager.getHashCode()
+    override fun toString(): String = string
 }

--- a/kotlin-utils/src/main/kotlin/xyz/lbres/kotlinutils/set/multiset/const/ConstMultiSetImpl.kt
+++ b/kotlin-utils/src/main/kotlin/xyz/lbres/kotlinutils/set/multiset/const/ConstMultiSetImpl.kt
@@ -10,8 +10,8 @@ internal class ConstMultiSetImpl<E>(initialElements: Collection<E>, initialCount
     private val manager: ConstMultiSetManager<E>
     override val size: Int = initialElements.size
     override val distinctValues: Set<E>
-    private val counts: Map<E, Int>
     private val string: String
+    val counts: Map<E, Int>
 
     init {
         counts = initialCounts.ifNull { createCountsMap(initialElements) }
@@ -35,5 +35,6 @@ internal class ConstMultiSetImpl<E>(initialElements: Collection<E>, initialCount
     override fun isEmpty(): Boolean = manager.isEmpty()
     override fun iterator(): Iterator<E> = manager.getIterator()
     override fun hashCode(): Int = manager.getHashCode()
+    override fun equals(other: Any?): Boolean = manager.equalsSet(other)
     override fun toString(): String = string
 }

--- a/kotlin-utils/src/main/kotlin/xyz/lbres/kotlinutils/set/multiset/const/ConstMultiSetManager.kt
+++ b/kotlin-utils/src/main/kotlin/xyz/lbres/kotlinutils/set/multiset/const/ConstMultiSetManager.kt
@@ -8,9 +8,6 @@ import xyz.lbres.kotlinutils.set.multiset.utils.createCountsMap
 import kotlin.math.min
 
 internal class ConstMultiSetManager<E>(private val elements: Collection<E>, private val counts: Map<E, Int>) {
-    private val distinctValues: Set<E>
-        get() = counts.keys
-
     fun getCountOf(element: E): Int = counts.getOrDefault(element, 0)
     fun isEmpty(): Boolean = counts.isEmpty()
 
@@ -42,8 +39,8 @@ internal class ConstMultiSetManager<E>(private val elements: Collection<E>, priv
         return combineCounts(other, { val1, val2 -> min(val1, val2) }, false, const = true) as ConstMultiSet<E>
     }
 
-    // TODO return new multiset
     private fun combineCounts(other: MultiSet<E>, operation: (count: Int, otherCount: Int) -> Int, useAllValues: Boolean, const: Boolean): MultiSet<E> {
+        val distinctValues = counts.keys
         val values: Set<E> = simpleIf(useAllValues, { distinctValues + other.distinctValues }, { distinctValues })
         val newCounts: Map<E, Int> = values.associateWith {
             operation(getCountOf(it), other.getCountOf(it))
@@ -53,7 +50,15 @@ internal class ConstMultiSetManager<E>(private val elements: Collection<E>, priv
         return simpleIf(const, { ConstMultiSetImpl(newElements, newCounts) }, { MultiSetImpl(newElements) })
     }
 
-    // TODO add equals
+    fun equalsSet(other: Any?): Boolean {
+        return when (other) {
+            is ConstMultiSetImpl<*> -> counts == other.counts
+            is ConstMutableMultiSetImpl<*> -> counts == other.counts
+            is MultiSet<*> -> counts == createCountsMap(other)
+            else -> false
+        }
+    }
+
     // TODO add toString
 
     /**

--- a/kotlin-utils/src/main/kotlin/xyz/lbres/kotlinutils/set/multiset/const/ConstMultiSetManager.kt
+++ b/kotlin-utils/src/main/kotlin/xyz/lbres/kotlinutils/set/multiset/const/ConstMultiSetManager.kt
@@ -1,8 +1,6 @@
 package xyz.lbres.kotlinutils.set.multiset.const
 
 import xyz.lbres.kotlinutils.general.simpleIf
-import xyz.lbres.kotlinutils.general.tryOrDefault
-import xyz.lbres.kotlinutils.internal.constants.Suppressions
 import xyz.lbres.kotlinutils.set.multiset.MultiSet
 import xyz.lbres.kotlinutils.set.multiset.impl.MultiSetImpl
 import xyz.lbres.kotlinutils.set.multiset.utils.countsToList
@@ -10,6 +8,8 @@ import xyz.lbres.kotlinutils.set.multiset.utils.createCountsMap
 import kotlin.math.min
 
 internal class ConstMultiSetManager<E>(private val elements: Collection<E>, private val counts: Map<E, Int>) {
+    private val distinctValues: Set<E>
+        get() = counts.keys
 
     fun getCountOf(element: E): Int = counts.getOrDefault(element, 0)
     fun isEmpty(): Boolean = counts.isEmpty()
@@ -24,37 +24,33 @@ internal class ConstMultiSetManager<E>(private val elements: Collection<E>, priv
     }
 
     fun plus(other: MultiSet<E>): MultiSet<E> {
-        val newCounts = combineCounts(other, Int::plus, true)
-        return MultiSetImpl(countsToList(newCounts))
+        return combineCounts(other, Int::plus, true, const = false)
     }
     fun minus(other: MultiSet<E>): MultiSet<E> {
-        val newCounts = combineCounts(other, Int::minus, false)
-        return MultiSetImpl(countsToList(newCounts))
+        return combineCounts(other, Int::minus, false, const = false)
     }
     fun intersect(other: MultiSet<E>): MultiSet<E> {
-        val newCounts = combineCounts(other, { val1, val2 -> min(val1, val2) }, false)
-        return MultiSetImpl(countsToList(newCounts))
+        return combineCounts(other, { val1, val2 -> min(val1, val2) }, false, const = false)
     }
     fun plusC(other: ConstMultiSet<E>): ConstMultiSet<E> {
-        val newCounts = combineCounts(other, Int::plus, true)
-        return ConstMultiSetImpl(countsToList(newCounts), newCounts)
+        return combineCounts(other, Int::plus, true, const = true) as ConstMultiSet<E>
     }
     fun minusC(other: ConstMultiSet<E>): ConstMultiSet<E> {
-        val newCounts = combineCounts(other, Int::minus, false)
-        return ConstMultiSetImpl(countsToList(newCounts), newCounts)
+        return combineCounts(other, Int::minus, false, const = true) as ConstMultiSet<E>
     }
     infix fun intersectC(other: ConstMultiSet<E>): ConstMultiSet<E> {
-        val newCounts = combineCounts(other, { val1, val2 -> min(val1, val2) }, false)
-        return ConstMultiSetImpl(countsToList(newCounts), newCounts)
+        return combineCounts(other, { val1, val2 -> min(val1, val2) }, false, const = true) as ConstMultiSet<E>
     }
 
     // TODO return new multiset
-    private fun combineCounts(other: MultiSet<E>, operation: (count: Int, otherCount: Int) -> Int, useAllValues: Boolean): Map<E, Int> {
-        val distinctValues = counts.keys
-        val values = simpleIf(useAllValues, { distinctValues + other.distinctValues }, { distinctValues })
-        return values.associateWith {
+    private fun combineCounts(other: MultiSet<E>, operation: (count: Int, otherCount: Int) -> Int, useAllValues: Boolean, const: Boolean): MultiSet<E> {
+        val values: Set<E> = simpleIf(useAllValues, { distinctValues + other.distinctValues }, { distinctValues })
+        val newCounts: Map<E, Int> = values.associateWith {
             operation(getCountOf(it), other.getCountOf(it))
         }.filter { it.value > 0 }
+        val newElements = countsToList(newCounts)
+
+        return simpleIf(const, { ConstMultiSetImpl(newElements, newCounts) }, { MultiSetImpl(newElements) })
     }
 
     // TODO add equals

--- a/kotlin-utils/src/main/kotlin/xyz/lbres/kotlinutils/set/multiset/const/ConstMultiSetManager.kt
+++ b/kotlin-utils/src/main/kotlin/xyz/lbres/kotlinutils/set/multiset/const/ConstMultiSetManager.kt
@@ -69,6 +69,12 @@ internal class ConstMultiSetManager<E>(private val counts: Map<E, Int>) {
         return simpleIf(const, { ConstMultiSetImpl(newElements, newCounts) }, { MultiSetImpl(newElements) })
     }
 
+    /**
+     * Check equality of the managed set to another MultiSet
+     *
+     * @param other [Any]?
+     * @return [Boolean] `true` if [other] is a MultiSet containing the same elements in the counts map
+     */
     fun equalsSet(other: Any?): Boolean {
         return when (other) {
             is ConstMultiSetImpl<*> -> counts == other.counts

--- a/kotlin-utils/src/main/kotlin/xyz/lbres/kotlinutils/set/multiset/const/ConstMultiSetManager.kt
+++ b/kotlin-utils/src/main/kotlin/xyz/lbres/kotlinutils/set/multiset/const/ConstMultiSetManager.kt
@@ -6,7 +6,12 @@ import xyz.lbres.kotlinutils.set.multiset.impl.MultiSetImpl
 import xyz.lbres.kotlinutils.set.multiset.utils.createCountsMap
 import kotlin.math.min
 
-internal class ConstMultiSetManager<E>(private val elements: Collection<E>, private val counts: Map<E, Int>) {
+/**
+ * Manager class for common ConstMultiSet code
+ *
+ * @param counts [Map]<E, Int>: counts map for set
+ */
+internal class ConstMultiSetManager<E>(private val counts: Map<E, Int>) {
     fun getCountOf(element: E): Int = counts.getOrDefault(element, 0)
     fun isEmpty(): Boolean = counts.isEmpty()
 
@@ -72,15 +77,6 @@ internal class ConstMultiSetManager<E>(private val elements: Collection<E>, priv
             else -> false
         }
     }
-
-    // TODO add toString
-
-    /**
-     * Get an iterator for the elements in this set.
-     *
-     * @return [Iterator]<E>
-     */
-    fun getIterator(): Iterator<E> = elements.iterator()
 
     /**
      * Get hash code for set.

--- a/kotlin-utils/src/main/kotlin/xyz/lbres/kotlinutils/set/multiset/const/ConstMultiSetManager.kt
+++ b/kotlin-utils/src/main/kotlin/xyz/lbres/kotlinutils/set/multiset/const/ConstMultiSetManager.kt
@@ -39,7 +39,7 @@ internal class ConstMultiSetManager<E>(private val counts: Map<E, Int>) {
     fun minusC(other: ConstMultiSet<E>): ConstMultiSet<E> {
         return combineCounts(other, Int::minus, false, const = true) as ConstMultiSet<E>
     }
-    infix fun intersectC(other: ConstMultiSet<E>): ConstMultiSet<E> {
+    fun intersectC(other: ConstMultiSet<E>): ConstMultiSet<E> {
         return combineCounts(other, ::min, false, const = true) as ConstMultiSet<E>
     }
 
@@ -53,8 +53,7 @@ internal class ConstMultiSetManager<E>(private val counts: Map<E, Int>) {
      * @return [MultiSet]<E>: new set where each element has the number of occurrences specified by the operation. If [const] is `true`, the set will be a const multi set
      */
     private fun combineCounts(other: MultiSet<E>, operation: (count: Int, otherCount: Int) -> Int, useAllValues: Boolean, const: Boolean): MultiSet<E> {
-        val distinctValues = counts.keys
-        val values: Set<E> = simpleIf(useAllValues, { distinctValues + other.distinctValues }, { distinctValues })
+        val values: Set<E> = simpleIf(useAllValues, { counts.keys + other.distinctValues }, { counts.keys })
         val newCounts: MutableMap<E, Int> = mutableMapOf()
         val newElements: MutableList<E> = mutableListOf()
 
@@ -73,7 +72,7 @@ internal class ConstMultiSetManager<E>(private val counts: Map<E, Int>) {
      * Check equality of the managed set to another MultiSet
      *
      * @param other [Any]?
-     * @return [Boolean] `true` if [other] is a MultiSet containing the same elements in the counts map
+     * @return [Boolean] `true` if [other] is a MultiSet containing the same elements as the counts map, `false` otherwise
      */
     fun equalsSet(other: Any?): Boolean {
         return when (other) {

--- a/kotlin-utils/src/main/kotlin/xyz/lbres/kotlinutils/set/multiset/const/ConstMultiSetManager.kt
+++ b/kotlin-utils/src/main/kotlin/xyz/lbres/kotlinutils/set/multiset/const/ConstMultiSetManager.kt
@@ -1,0 +1,79 @@
+package xyz.lbres.kotlinutils.set.multiset.const
+
+import xyz.lbres.kotlinutils.general.simpleIf
+import xyz.lbres.kotlinutils.general.tryOrDefault
+import xyz.lbres.kotlinutils.internal.constants.Suppressions
+import xyz.lbres.kotlinutils.set.multiset.MultiSet
+import xyz.lbres.kotlinutils.set.multiset.impl.MultiSetImpl
+import xyz.lbres.kotlinutils.set.multiset.utils.countsToList
+import xyz.lbres.kotlinutils.set.multiset.utils.createCountsMap
+import kotlin.math.min
+
+internal class ConstMultiSetManager<E>(private val elements: Collection<E>, private val counts: Map<E, Int>) {
+
+    fun getCountOf(element: E): Int = counts.getOrDefault(element, 0)
+    fun isEmpty(): Boolean = counts.isEmpty()
+
+    fun contains(element: E): Boolean = counts.contains(element)
+    fun containsAll(elements: Collection<E>): Boolean {
+        val otherCounts = createCountsMap(elements)
+
+        return otherCounts.all { (element, otherCount) ->
+            otherCount <= getCountOf(element)
+        }
+    }
+
+    fun plus(other: MultiSet<E>): MultiSet<E> {
+        val newCounts = combineCounts(other, Int::plus, true)
+        return MultiSetImpl(countsToList(newCounts))
+    }
+    fun minus(other: MultiSet<E>): MultiSet<E> {
+        val newCounts = combineCounts(other, Int::minus, false)
+        return MultiSetImpl(countsToList(newCounts))
+    }
+    fun intersect(other: MultiSet<E>): MultiSet<E> {
+        val newCounts = combineCounts(other, { val1, val2 -> min(val1, val2) }, false)
+        return MultiSetImpl(countsToList(newCounts))
+    }
+    fun plusC(other: ConstMultiSet<E>): ConstMultiSet<E> {
+        val newCounts = combineCounts(other, Int::plus, true)
+        return ConstMultiSetImpl(countsToList(newCounts), newCounts)
+    }
+    fun minusC(other: ConstMultiSet<E>): ConstMultiSet<E> {
+        val newCounts = combineCounts(other, Int::minus, false)
+        return ConstMultiSetImpl(countsToList(newCounts), newCounts)
+    }
+    infix fun intersectC(other: ConstMultiSet<E>): ConstMultiSet<E> {
+        val newCounts = combineCounts(other, { val1, val2 -> min(val1, val2) }, false)
+        return ConstMultiSetImpl(countsToList(newCounts), newCounts)
+    }
+
+    // TODO return new multiset
+    private fun combineCounts(other: MultiSet<E>, operation: (count: Int, otherCount: Int) -> Int, useAllValues: Boolean): Map<E, Int> {
+        val distinctValues = counts.keys
+        val values = simpleIf(useAllValues, { distinctValues + other.distinctValues }, { distinctValues })
+        return values.associateWith {
+            operation(getCountOf(it), other.getCountOf(it))
+        }.filter { it.value > 0 }
+    }
+
+    // TODO add equals
+    // TODO add toString
+
+    /**
+     * Get an iterator for the elements in this set.
+     *
+     * @return [Iterator]<E>
+     */
+    fun getIterator(): Iterator<E> = elements.iterator()
+
+    /**
+     * Get hash code for set.
+     *
+     * @return [Int]
+     */
+    fun getHashCode(): Int {
+        val hashCode = counts.hashCode()
+        return 31 * hashCode + MultiSet::class.java.name.hashCode()
+    }
+}

--- a/kotlin-utils/src/main/kotlin/xyz/lbres/kotlinutils/set/multiset/const/ConstMutableMultiSet.kt
+++ b/kotlin-utils/src/main/kotlin/xyz/lbres/kotlinutils/set/multiset/const/ConstMutableMultiSet.kt
@@ -1,164 +1,18 @@
 package xyz.lbres.kotlinutils.set.multiset.const
 
 import xyz.lbres.kotlinutils.set.multiset.MutableMultiSet
-import xyz.lbres.kotlinutils.set.multiset.utils.countsToList
-import xyz.lbres.kotlinutils.set.multiset.utils.countsToString
-import xyz.lbres.kotlinutils.set.multiset.utils.createCountsMap
-import kotlin.math.min
 
 /**
  * [MutableMultiSet] implementation where values of elements are assumed to be constant.
  * Behavior is not defined if values of elements are changed (i.e. elements are added to a mutable list).
  */
 sealed class ConstMutableMultiSet<E> constructor(initialElements: Collection<E>) : MutableMultiSet<E>, ConstMultiSet<E>(initialElements) {
-    /**
-     * If all properties are up-to-date with the most recent changes to the counts map
-     */
-    private var allPropertiesUpdated: Boolean = false
-
-    // elements list is up-to-date only when allPropertiesUpdated == true
-    private var _elements: List<E> = initialElements.toList()
-    override val elements: Collection<E>
-        get() {
-            updateMutableValues() // update elements before returning value
-            return _elements
-        }
-
-    // string is up-to-date only when allPropertiesUpdated == true
-    private var _string: String = ""
-    override val string: String
-        get() {
-            updateMutableValues() // update string before returning value
-            return _string
-        }
-
     override val counts: MutableMap<E, Int> = initializeCounts().toMutableMap()
-
-    override val distinctValues: Set<E>
-        get() = counts.keys
-
-    /**
-     * Add one occurrence of the specified element to the set.
-     *
-     * @param element [E]
-     * @return [Boolean]: `true` if the element has been added successfully, `false` otherwise
-     */
-    override fun add(element: E): Boolean {
-        allPropertiesUpdated = false
-        counts[element] = getCountOf(element) + 1
-        _size++
-        return true
-    }
-
-    /**
-     * Add all specified elements to the set.
-     * If [elements] contains multiple occurrences of the same value, the value will be added multiple times.
-     *
-     * @param elements [Collection]<E>
-     * @return [Boolean]: `true` if any elements have been added successfully, `false` otherwise
-     */
-    override fun addAll(elements: Collection<E>): Boolean {
-        allPropertiesUpdated = false
-        elements.forEach(this::add)
-        return true
-    }
-
-    /**
-     * Remove one occurrence of the specified element from the set, if the element exists.
-     *
-     * @param element [E]
-     * @return [Boolean]: `true` if the element has been removed successfully, `false` otherwise
-     */
-    override fun remove(element: E): Boolean {
-        when (getCountOf(element)) {
-            0 -> return false
-            1 -> counts.remove(element)
-            else -> counts[element] = getCountOf(element) - 1
-        }
-
-        allPropertiesUpdated = false
-        _size--
-        return true
-    }
-
-    /**
-     * Remove all specified elements from the set.
-     * If [elements] contains a single occurrence of a value, only one occurrence of the value will be removed from the set.
-     * If there are multiple occurrences, the value will be removed multiple times.
-     *
-     * @param elements [Collection]<E>
-     * @return [Boolean]: `true` if any elements have been removed successfully, `false` otherwise
-     */
-    override fun removeAll(elements: Collection<E>): Boolean {
-        if (elements.isEmpty()) {
-            return true
-        }
-
-        var anySucceeded = false
-        elements.forEach { anySucceeded = remove(it) || anySucceeded }
-        allPropertiesUpdated = allPropertiesUpdated && !anySucceeded
-
-        return anySucceeded
-    }
-
-    /**
-     * Retain only elements that are present in [elements].
-     * If [elements] contains multiple occurrences of the same value, the value will retain up to that number of occurrences.
-     *
-     * @param elements [Collection]<E>
-     * @return [Boolean]: `true` if elements have been retained successfully, `false` otherwise
-     */
-    override fun retainAll(elements: Collection<E>): Boolean {
-        val initialSize = size
-        val elementsCounts = createCountsMap(elements)
-
-        val newCounts = distinctValues.associateWith {
-            min(getCountOf(it), elementsCounts.getOrDefault(it, 0))
-        }
-
-        counts.clear()
-        _size = 0
-
-        newCounts.forEach { (element, count) ->
-            if (count > 0) {
-                counts[element] = count
-                _size += count
-            }
-        }
-
-        allPropertiesUpdated = allPropertiesUpdated && size == initialSize
-
-        return true
-    }
-
-    /**
-     * Remove all elements from the set.
-     */
-    override fun clear() {
-        counts.clear()
-        _size = 0
-        allPropertiesUpdated = false
-    }
 
     /**
      * Get an iterator for the elements in this set.
      *
      * @return [MutableIterator]<E>
      */
-    override fun iterator(): MutableIterator<E> {
-        updateMutableValues()
-        return _elements.toMutableList().iterator()
-    }
-
-    /**
-     * Update the elements list and string based on the current values in the counts map
-     */
-    private fun updateMutableValues() {
-        if (!allPropertiesUpdated) {
-            _elements = countsToList(counts)
-            _string = countsToString(counts)
-
-            allPropertiesUpdated = true
-        }
-    }
+    abstract override fun iterator(): MutableIterator<E>
 }

--- a/kotlin-utils/src/main/kotlin/xyz/lbres/kotlinutils/set/multiset/const/ConstMutableMultiSet.kt
+++ b/kotlin-utils/src/main/kotlin/xyz/lbres/kotlinutils/set/multiset/const/ConstMutableMultiSet.kt
@@ -7,8 +7,6 @@ import xyz.lbres.kotlinutils.set.multiset.MutableMultiSet
  * Behavior is not defined if values of elements are changed (i.e. elements are added to a mutable list).
  */
 sealed class ConstMutableMultiSet<E> constructor(initialElements: Collection<E>) : MutableMultiSet<E>, ConstMultiSet<E>(initialElements) {
-    override val counts: MutableMap<E, Int> = initializeCounts().toMutableMap()
-
     /**
      * Get an iterator for the elements in this set.
      *

--- a/kotlin-utils/src/main/kotlin/xyz/lbres/kotlinutils/set/multiset/const/ConstMutableMultiSetImpl.kt
+++ b/kotlin-utils/src/main/kotlin/xyz/lbres/kotlinutils/set/multiset/const/ConstMutableMultiSetImpl.kt
@@ -33,7 +33,7 @@ internal class ConstMutableMultiSetImpl<E>(initialElements: Collection<E>) : Con
 
     init {
         _counts = createCountsMap(initialElements).toMutableMap()
-        manager = ConstMultiSetManager(elements, _counts)
+        manager = ConstMultiSetManager(_counts)
     }
 
     override fun add(element: E): Boolean {

--- a/kotlin-utils/src/main/kotlin/xyz/lbres/kotlinutils/set/multiset/const/ConstMutableMultiSetImpl.kt
+++ b/kotlin-utils/src/main/kotlin/xyz/lbres/kotlinutils/set/multiset/const/ConstMutableMultiSetImpl.kt
@@ -23,7 +23,7 @@ internal class ConstMutableMultiSetImpl<E>(initialElements: Collection<E>) : Con
     // elements list is up-to-date only when allPropertiesUpdated == true
     private var elements: List<E> = initialElements.toList()
 
-    private var _size: Int = initialElements.size
+    private var _size: Int = elements.size
     override val size: Int
         get() = _size
 
@@ -66,8 +66,7 @@ internal class ConstMutableMultiSetImpl<E>(initialElements: Collection<E>) : Con
             return true
         }
 
-        var anySucceeded = false
-        elements.forEach { anySucceeded = remove(it) || anySucceeded }
+        val anySucceeded = elements.fold(false) { succeeded, element -> remove(element) || succeeded }
         allPropertiesUpdated = allPropertiesUpdated && !anySucceeded
 
         return anySucceeded

--- a/kotlin-utils/src/main/kotlin/xyz/lbres/kotlinutils/set/multiset/const/ConstMutableMultiSetImpl.kt
+++ b/kotlin-utils/src/main/kotlin/xyz/lbres/kotlinutils/set/multiset/const/ConstMutableMultiSetImpl.kt
@@ -76,17 +76,14 @@ internal class ConstMutableMultiSetImpl<E>(initialElements: Collection<E>) : Con
         val initialSize = size
         val elementsCounts = createCountsMap(elements)
 
-        val newCounts = distinctValues.associateWith {
-            min(getCountOf(it), elementsCounts.getOrDefault(it, 0))
-        }
-
-        _counts.clear()
         _size = 0
-
-        newCounts.forEach { (element, count) ->
-            if (count > 0) {
-                _counts[element] = count
-                _size += count
+        distinctValues.forEach {
+            val newCount = min(getCountOf(it), elementsCounts.getOrDefault(it, 0))
+            if (newCount > 0) {
+                _counts[it] = newCount
+                _size += newCount
+            } else {
+                _counts.remove(it)
             }
         }
 

--- a/kotlin-utils/src/main/kotlin/xyz/lbres/kotlinutils/set/multiset/const/ConstMutableMultiSetImpl.kt
+++ b/kotlin-utils/src/main/kotlin/xyz/lbres/kotlinutils/set/multiset/const/ConstMutableMultiSetImpl.kt
@@ -23,11 +23,6 @@ internal class ConstMutableMultiSetImpl<E>(initialElements: Collection<E>) : Con
 
     // elements list is up-to-date only when allPropertiesUpdated == true
     private var _elements: List<E> = initialElements.toList()
-    private val elements: Collection<E>
-        get() {
-            updateMutableValues()
-            return _elements
-        }
 
     private var _size: Int = initialElements.size
     override val size: Int
@@ -38,7 +33,7 @@ internal class ConstMutableMultiSetImpl<E>(initialElements: Collection<E>) : Con
 
     init {
         _counts = createCountsMap(initialElements).toMutableMap()
-        manager = ConstMultiSetManager(elements, _counts)
+        manager = ConstMultiSetManager(_elements, _counts)
     }
 
     override fun add(element: E): Boolean {

--- a/kotlin-utils/src/main/kotlin/xyz/lbres/kotlinutils/set/multiset/const/ConstMutableMultiSetImpl.kt
+++ b/kotlin-utils/src/main/kotlin/xyz/lbres/kotlinutils/set/multiset/const/ConstMutableMultiSetImpl.kt
@@ -1,4 +1,124 @@
 package xyz.lbres.kotlinutils.set.multiset.const
 
+import xyz.lbres.kotlinutils.set.multiset.utils.countsToList
+import xyz.lbres.kotlinutils.set.multiset.utils.countsToString
+import xyz.lbres.kotlinutils.set.multiset.utils.createCountsMap
+import kotlin.math.min
+
 // final implementation of ConstMutableMultiSet
-internal class ConstMutableMultiSetImpl<E>(initialElements: Collection<E>) : ConstMutableMultiSet<E>(initialElements)
+internal class ConstMutableMultiSetImpl<E>(initialElements: Collection<E>) : ConstMutableMultiSet<E>(initialElements) {
+    /**
+     * If all properties are up-to-date with the most recent changes to the counts map
+     */
+    private var allPropertiesUpdated: Boolean = false
+
+    private val manager: ConstMultiSetManager<E>
+    override val counts: MutableMap<E, Int>
+
+    override val distinctValues: Set<E>
+        get() = counts.keys
+
+    // elements list is up-to-date only when allPropertiesUpdated == true
+    private var _elements: List<E> = initialElements.toList()
+    override val elements: Collection<E>
+        get() {
+            updateMutableValues()
+            return _elements
+        }
+
+    // string is up-to-date only when allPropertiesUpdated == true
+    private var _string: String = ""
+    override val string: String
+        get() {
+            updateMutableValues() // update string before returning value
+            return _string
+        }
+
+    init {
+        counts = createCountsMap(initialElements).toMutableMap()
+        manager = ConstMultiSetManager(elements, counts)
+    }
+
+    override fun add(element: E): Boolean {
+        allPropertiesUpdated = false
+        counts[element] = getCountOf(element) + 1
+        _size++
+        return true
+    }
+
+    override fun addAll(elements: Collection<E>): Boolean {
+        allPropertiesUpdated = false
+        elements.forEach(this::add)
+        return true
+    }
+
+    override fun remove(element: E): Boolean {
+        when (getCountOf(element)) {
+            0 -> return false
+            1 -> counts.remove(element)
+            else -> counts[element] = getCountOf(element) - 1
+        }
+
+        allPropertiesUpdated = false
+        _size--
+        return true
+    }
+
+    override fun removeAll(elements: Collection<E>): Boolean {
+        if (elements.isEmpty()) {
+            return true
+        }
+
+        var anySucceeded = false
+        elements.forEach { anySucceeded = remove(it) || anySucceeded }
+        allPropertiesUpdated = allPropertiesUpdated && !anySucceeded
+
+        return anySucceeded
+    }
+
+    override fun retainAll(elements: Collection<E>): Boolean {
+        val initialSize = size
+        val elementsCounts = createCountsMap(elements)
+
+        val newCounts = distinctValues.associateWith {
+            min(getCountOf(it), elementsCounts.getOrDefault(it, 0))
+        }
+
+        counts.clear()
+        _size = 0
+
+        newCounts.forEach { (element, count) ->
+            if (count > 0) {
+                counts[element] = count
+                _size += count
+            }
+        }
+
+        allPropertiesUpdated = allPropertiesUpdated && size == initialSize
+
+        return true
+    }
+
+    override fun clear() {
+        counts.clear()
+        _size = 0
+        allPropertiesUpdated = false
+    }
+
+    override fun iterator(): MutableIterator<E> {
+        updateMutableValues()
+        return _elements.toMutableList().iterator()
+    }
+
+    /**
+     * Update the elements list and string based on the current values in the counts map
+     */
+    private fun updateMutableValues() {
+        if (!allPropertiesUpdated) {
+            _elements = countsToList(counts)
+            _string = countsToString(counts)
+
+            allPropertiesUpdated = true
+        }
+    }
+}

--- a/kotlin-utils/src/main/kotlin/xyz/lbres/kotlinutils/set/multiset/const/ConstMutableMultiSetImpl.kt
+++ b/kotlin-utils/src/main/kotlin/xyz/lbres/kotlinutils/set/multiset/const/ConstMutableMultiSetImpl.kt
@@ -1,5 +1,6 @@
 package xyz.lbres.kotlinutils.set.multiset.const
 
+import xyz.lbres.kotlinutils.set.multiset.MultiSet
 import xyz.lbres.kotlinutils.set.multiset.utils.countsToList
 import xyz.lbres.kotlinutils.set.multiset.utils.countsToString
 import xyz.lbres.kotlinutils.set.multiset.utils.createCountsMap
@@ -13,26 +14,25 @@ internal class ConstMutableMultiSetImpl<E>(initialElements: Collection<E>) : Con
     private var allPropertiesUpdated: Boolean = false
 
     private val manager: ConstMultiSetManager<E>
-    override val counts: MutableMap<E, Int>
+    private val counts: MutableMap<E, Int>
 
     override val distinctValues: Set<E>
         get() = counts.keys
 
     // elements list is up-to-date only when allPropertiesUpdated == true
     private var _elements: List<E> = initialElements.toList()
-    override val elements: Collection<E>
+    private val elements: Collection<E>
         get() {
             updateMutableValues()
             return _elements
         }
 
+    private var _size: Int = initialElements.size
+    override val size: Int
+        get() = _size
+
     // string is up-to-date only when allPropertiesUpdated == true
-    private var _string: String = ""
-    override val string: String
-        get() {
-            updateMutableValues() // update string before returning value
-            return _string
-        }
+    private var string: String = ""
 
     init {
         counts = createCountsMap(initialElements).toMutableMap()
@@ -105,9 +105,29 @@ internal class ConstMutableMultiSetImpl<E>(initialElements: Collection<E>) : Con
         allPropertiesUpdated = false
     }
 
+    override fun getCountOf(element: E): Int = manager.getCountOf(element)
+    override fun contains(element: E): Boolean = manager.contains(element)
+    override fun containsAll(elements: Collection<E>): Boolean = manager.containsAll(elements)
+
+    override fun plus(other: MultiSet<E>): MultiSet<E> = manager.plus(other)
+    override fun minus(other: MultiSet<E>): MultiSet<E> = manager.minus(other)
+    override fun intersect(other: MultiSet<E>): MultiSet<E> = manager.intersect(other)
+
+    override fun plusC(other: ConstMultiSet<E>): ConstMultiSet<E> = manager.plusC(other)
+    override fun minusC(other: ConstMultiSet<E>): ConstMultiSet<E> = manager.minusC(other)
+    override fun intersectC(other: ConstMultiSet<E>): ConstMultiSet<E> = manager.intersectC(other)
+
+    override fun isEmpty(): Boolean = manager.isEmpty()
+    override fun hashCode(): Int = manager.getHashCode()
+
     override fun iterator(): MutableIterator<E> {
         updateMutableValues()
         return _elements.toMutableList().iterator()
+    }
+
+    override fun toString(): String {
+        updateMutableValues() // update string before returning value
+        return string
     }
 
     /**
@@ -116,7 +136,7 @@ internal class ConstMutableMultiSetImpl<E>(initialElements: Collection<E>) : Con
     private fun updateMutableValues() {
         if (!allPropertiesUpdated) {
             _elements = countsToList(counts)
-            _string = countsToString(counts)
+            string = countsToString(counts)
 
             allPropertiesUpdated = true
         }

--- a/kotlin-utils/src/main/kotlin/xyz/lbres/kotlinutils/set/multiset/const/ConstMutableMultiSetImpl.kt
+++ b/kotlin-utils/src/main/kotlin/xyz/lbres/kotlinutils/set/multiset/const/ConstMutableMultiSetImpl.kt
@@ -16,7 +16,6 @@ internal class ConstMutableMultiSetImpl<E>(initialElements: Collection<E>) : Con
     private val manager: ConstMultiSetManager<E>
     private val _counts: MutableMap<E, Int>
     val counts: Map<E, Int>
-        get() = _counts
 
     override val distinctValues: Set<E>
         get() = _counts.keys
@@ -33,6 +32,7 @@ internal class ConstMutableMultiSetImpl<E>(initialElements: Collection<E>) : Con
 
     init {
         _counts = createCountsMap(initialElements).toMutableMap()
+        counts = _counts
         manager = ConstMultiSetManager(_counts)
     }
 

--- a/kotlin-utils/src/main/kotlin/xyz/lbres/kotlinutils/set/multiset/const/ConstMutableMultiSetImpl.kt
+++ b/kotlin-utils/src/main/kotlin/xyz/lbres/kotlinutils/set/multiset/const/ConstMutableMultiSetImpl.kt
@@ -22,7 +22,7 @@ internal class ConstMutableMultiSetImpl<E>(initialElements: Collection<E>) : Con
         get() = _counts.keys
 
     // elements list is up-to-date only when allPropertiesUpdated == true
-    private var _elements: List<E> = initialElements.toList()
+    private var elements: List<E> = initialElements.toList()
 
     private var _size: Int = initialElements.size
     override val size: Int
@@ -33,7 +33,7 @@ internal class ConstMutableMultiSetImpl<E>(initialElements: Collection<E>) : Con
 
     init {
         _counts = createCountsMap(initialElements).toMutableMap()
-        manager = ConstMultiSetManager(_elements, _counts)
+        manager = ConstMultiSetManager(elements, _counts)
     }
 
     override fun add(element: E): Boolean {
@@ -120,7 +120,7 @@ internal class ConstMutableMultiSetImpl<E>(initialElements: Collection<E>) : Con
 
     override fun iterator(): MutableIterator<E> {
         updateMutableValues()
-        return _elements.toMutableList().iterator()
+        return elements.toMutableList().iterator()
     }
 
     override fun toString(): String {
@@ -133,7 +133,7 @@ internal class ConstMutableMultiSetImpl<E>(initialElements: Collection<E>) : Con
      */
     private fun updateMutableValues() {
         if (!allPropertiesUpdated) {
-            _elements = countsToList(_counts)
+            elements = countsToList(_counts)
             string = countsToString(_counts)
 
             allPropertiesUpdated = true

--- a/kotlin-utils/src/main/kotlin/xyz/lbres/kotlinutils/set/multiset/impl/AbstractMultiSetImpl.kt
+++ b/kotlin-utils/src/main/kotlin/xyz/lbres/kotlinutils/set/multiset/impl/AbstractMultiSetImpl.kt
@@ -27,8 +27,7 @@ internal abstract class AbstractMultiSetImpl<E>(private val initialElements: Col
     /**
      * Elements in the set.
      */
-    protected open val elements: Collection<E>
-        get() = initialElements
+    protected open val elements: Collection<E> = initialElements
 
     /**
      * Get the number of occurrences of a given element.


### PR DESCRIPTION
## What was changed?
- Move majority of function into ConstMultiSetImpl, ConstMutableMultiSetImpl, and new ConstMultiSetManager classes

## Checks
- [x] New and existing unit tests pass with my changes
- [ ] Unit tests have been written for all new and changed functions
- [x] Comments have been added where needed
- [x] Docstrings have been updated with any modified function signatures
- [x] ktlint has run successfully
- [ ] The version number has been updated if necessary

## How was this tested?
Existing unit tests to ensure that refactor did not change functionality

## Additional Comments
We <3 tests
