### PR TITLE
MultiSet test helper cleanup

### DIFF
--- a/kotlin-utils/src/test/kotlin/xyz/lbres/kotlinutils/set/multiset/const/ConstMultiSetTest.kt
+++ b/kotlin-utils/src/test/kotlin/xyz/lbres/kotlinutils/set/multiset/const/ConstMultiSetTest.kt
@@ -25,29 +25,29 @@ class ConstMultiSetTest {
         multiSetConstructorCompListTestValues.forEach { runTest<List<Comparable<*>>>(it) }
     }
 
-    @Test fun testEquals() = runEqualsTests(createSet(), createSet(), createSet(), createOtherSet())
+    @Test fun testEquals() = runEqualsTests(createSet(), createOtherSet())
 
-    @Test fun testContains() = runContainsTests(createSet(), createSet(), createSet())
+    @Test fun testContains() = runContainsTests(createSet())
     @Test fun testContainsAll() = runContainsAllTests(createSet())
 
     @Test
     fun testMinus() {
-        runMinusTests(createSet(), createSet(), createSet(), createSet(), createOtherSet())
+        runMinusTests(createSet(), createOtherSet())
     }
 
     @Test
     fun testPlus() {
-        runPlusTests(createSet(), createSet(), createSet(), createSet(), createOtherSet())
+        runPlusTests(createSet(), createOtherSet())
     }
 
     @Test
     fun testIntersect() {
-        runIntersectTests(createSet(), createSet(), createSet(), createOtherSet())
+        runIntersectTests(createSet(), createOtherSet())
     }
 
-    @Test fun testIsEmpty() = runIsEmptyTests(createSet(), createSet())
-    @Test fun testGetCountOf() = runGetCountOfTests(createSet(), createSet())
+    @Test fun testIsEmpty() = runIsEmptyTests(createSet())
+    @Test fun testGetCountOf() = runGetCountOfTests(createSet())
 
-    @Test fun testIterator() = runIteratorTests(createSet(), createSet())
-    @Test fun testToString() = runToStringTests(createSet(), createSet())
+    @Test fun testIterator() = runIteratorTests(createSet())
+    @Test fun testToString() = runToStringTests(createSet())
 }

--- a/kotlin-utils/src/test/kotlin/xyz/lbres/kotlinutils/set/multiset/const/ConstMultiSetTest.kt
+++ b/kotlin-utils/src/test/kotlin/xyz/lbres/kotlinutils/set/multiset/const/ConstMultiSetTest.kt
@@ -7,9 +7,6 @@ import xyz.lbres.kotlinutils.set.multiset.testutils.* // ktlint-disable no-wildc
 import kotlin.test.Test
 
 class ConstMultiSetTest {
-    private fun <T> createSet(): (Collection<T>) -> ConstMultiSet<T> = { ConstMultiSetImpl(it) }
-    private fun <T> createOtherSet(): (Collection<T>) -> MutableMultiSetImpl<T> = { MutableMultiSetImpl(it) }
-
     @Test
     fun testConstructor() {
         fun <T> runTest(map: Map<String, Any>) {
@@ -25,29 +22,18 @@ class ConstMultiSetTest {
         multiSetConstructorCompListTestValues.forEach { runTest<List<Comparable<*>>>(it) }
     }
 
-    @Test fun testEquals() = runEqualsTests(createSet(), createOtherSet())
+    @Test fun testEquals() = runEqualsTests(::ConstMultiSetImpl, ::MutableMultiSetImpl)
 
-    @Test fun testContains() = runContainsTests(createSet())
-    @Test fun testContainsAll() = runContainsAllTests(createSet())
+    @Test fun testContains() = runContainsTests(::ConstMultiSetImpl)
+    @Test fun testContainsAll() = runContainsAllTests(::ConstMultiSetImpl)
 
-    @Test
-    fun testMinus() {
-        runMinusTests(createSet(), createOtherSet())
-    }
+    @Test fun testMinus() = runMinusTests(::ConstMultiSetImpl, ::MutableMultiSetImpl)
+    @Test fun testPlus() = runPlusTests(::ConstMultiSetImpl, ::MutableMultiSetImpl)
+    @Test fun testIntersect() = runIntersectTests(::ConstMultiSetImpl, ::MutableMultiSetImpl)
 
-    @Test
-    fun testPlus() {
-        runPlusTests(createSet(), createOtherSet())
-    }
+    @Test fun testIsEmpty() = runIsEmptyTests(::ConstMultiSetImpl)
+    @Test fun testGetCountOf() = runGetCountOfTests(::ConstMultiSetImpl)
 
-    @Test
-    fun testIntersect() {
-        runIntersectTests(createSet(), createOtherSet())
-    }
-
-    @Test fun testIsEmpty() = runIsEmptyTests(createSet())
-    @Test fun testGetCountOf() = runGetCountOfTests(createSet())
-
-    @Test fun testIterator() = runIteratorTests(createSet())
-    @Test fun testToString() = runToStringTests(createSet())
+    @Test fun testIterator() = runIteratorTests(::ConstMultiSetImpl)
+    @Test fun testToString() = runToStringTests(::ConstMultiSetImpl)
 }

--- a/kotlin-utils/src/test/kotlin/xyz/lbres/kotlinutils/set/multiset/const/ConstMutableMultiSetTest.kt
+++ b/kotlin-utils/src/test/kotlin/xyz/lbres/kotlinutils/set/multiset/const/ConstMutableMultiSetTest.kt
@@ -25,9 +25,9 @@ class ConstMutableMultiSetTest {
         multiSetConstructorCompListTestValues.forEach { runTest<List<Comparable<*>>>(it) }
     }
 
-    @Test fun testEquals() = runMutableEqualsTests(createSet(), createSet(), createSet(), createOtherSet())
+    @Test fun testEquals() = runMutableEqualsTests(createSet(), createOtherSet())
 
-    @Test fun testContains() = runMutableContainsTests(createSet(), createSet(), createSet())
+    @Test fun testContains() = runMutableContainsTests(createSet())
     @Test fun testContainsAll() = runMutableContainsAllTests(createSet())
 
     @Test fun testClear() = runClearTests(createSet())
@@ -39,22 +39,22 @@ class ConstMutableMultiSetTest {
 
     @Test
     fun testMinus() {
-        runMinusTests(createSet(), createSet(), createSet(), createSet(), createOtherSet())
+        runMinusTests(createSet(), createOtherSet())
     }
 
     @Test
     fun testPlus() {
-        runPlusTests(createSet(), createSet(), createSet(), createSet(), createOtherSet())
+        runPlusTests(createSet(), createOtherSet())
     }
 
     @Test
     fun testIntersect() {
-        runIntersectTests(createSet(), createSet(), createSet(), createOtherSet())
+        runIntersectTests(createSet(), createOtherSet())
     }
 
-    @Test fun testIsEmpty() = runMutableIsEmptyTests(createSet(), createSet())
-    @Test fun testGetCountOf() = runMutableGetCountOfTests(createSet(), createSet())
+    @Test fun testIsEmpty() = runMutableIsEmptyTests(createSet())
+    @Test fun testGetCountOf() = runMutableGetCountOfTests(createSet())
 
-    @Test fun testIterator() = runMutableIteratorTests(createSet(), createSet())
-    @Test fun testToString() = runMutableToStringTests(createSet(), createSet())
+    @Test fun testIterator() = runMutableIteratorTests(createSet())
+    @Test fun testToString() = runMutableToStringTests(createSet())
 }

--- a/kotlin-utils/src/test/kotlin/xyz/lbres/kotlinutils/set/multiset/const/ConstMutableMultiSetTest.kt
+++ b/kotlin-utils/src/test/kotlin/xyz/lbres/kotlinutils/set/multiset/const/ConstMutableMultiSetTest.kt
@@ -7,9 +7,6 @@ import xyz.lbres.kotlinutils.set.multiset.testutils.* // ktlint-disable no-wildc
 import kotlin.test.Test
 
 class ConstMutableMultiSetTest {
-    private fun <T> createSet(): (Collection<T>) -> ConstMutableMultiSet<T> = { ConstMutableMultiSetImpl(it) }
-    private fun <T> createOtherSet(): (Collection<T>) -> MultiSetImpl<T> = { MultiSetImpl(it) }
-
     @Test
     fun testConstructor() {
         fun <T> runTest(map: Map<String, Any>) {
@@ -25,36 +22,25 @@ class ConstMutableMultiSetTest {
         multiSetConstructorCompListTestValues.forEach { runTest<List<Comparable<*>>>(it) }
     }
 
-    @Test fun testEquals() = runMutableEqualsTests(createSet(), createOtherSet())
+    @Test fun testEquals() = runMutableEqualsTests(::ConstMutableMultiSetImpl, ::MultiSetImpl)
 
-    @Test fun testContains() = runMutableContainsTests(createSet())
-    @Test fun testContainsAll() = runMutableContainsAllTests(createSet())
+    @Test fun testContains() = runMutableContainsTests(::ConstMutableMultiSetImpl)
+    @Test fun testContainsAll() = runMutableContainsAllTests(::ConstMutableMultiSetImpl)
 
-    @Test fun testClear() = runClearTests(createSet())
-    @Test fun testAdd() = runAddTests(createSet(), createSet())
-    @Test fun testAddAll() = runAddAllTests(createSet())
-    @Test fun testRemove() = runRemoveTests(createSet())
-    @Test fun testRemoveAll() = runRemoveAllTests(createSet())
-    @Test fun testRetainAll() = runClearTests(createSet())
+    @Test fun testClear() = runClearTests(::ConstMutableMultiSetImpl)
+    @Test fun testAdd() = runAddTests(::ConstMutableMultiSetImpl)
+    @Test fun testAddAll() = runAddAllTests(::ConstMutableMultiSetImpl)
+    @Test fun testRemove() = runRemoveTests(::ConstMutableMultiSetImpl)
+    @Test fun testRemoveAll() = runRemoveAllTests(::ConstMutableMultiSetImpl)
+    @Test fun testRetainAll() = runClearTests(::ConstMutableMultiSetImpl)
 
-    @Test
-    fun testMinus() {
-        runMinusTests(createSet(), createOtherSet())
-    }
+    @Test fun testMinus() = runMinusTests(::ConstMutableMultiSetImpl, ::MultiSetImpl)
+    @Test fun testPlus() = runPlusTests(::ConstMutableMultiSetImpl, ::MultiSetImpl)
+    @Test fun testIntersect() = runIntersectTests(::ConstMutableMultiSetImpl, ::MultiSetImpl)
 
-    @Test
-    fun testPlus() {
-        runPlusTests(createSet(), createOtherSet())
-    }
+    @Test fun testIsEmpty() = runMutableIsEmptyTests(::ConstMutableMultiSetImpl)
+    @Test fun testGetCountOf() = runMutableGetCountOfTests(::ConstMutableMultiSetImpl)
 
-    @Test
-    fun testIntersect() {
-        runIntersectTests(createSet(), createOtherSet())
-    }
-
-    @Test fun testIsEmpty() = runMutableIsEmptyTests(createSet())
-    @Test fun testGetCountOf() = runMutableGetCountOfTests(createSet())
-
-    @Test fun testIterator() = runMutableIteratorTests(createSet())
-    @Test fun testToString() = runMutableToStringTests(createSet())
+    @Test fun testIterator() = runMutableIteratorTests(::ConstMutableMultiSetImpl)
+    @Test fun testToString() = runMutableToStringTests(::ConstMutableMultiSetImpl)
 }

--- a/kotlin-utils/src/test/kotlin/xyz/lbres/kotlinutils/set/multiset/impl/MultiSetImplTest.kt
+++ b/kotlin-utils/src/test/kotlin/xyz/lbres/kotlinutils/set/multiset/impl/MultiSetImplTest.kt
@@ -28,13 +28,13 @@ class MultiSetImplTest {
 
     @Test
     fun testEquals() {
-        runEqualsTests(createSet(), createSet(), createSet(), createOtherSet())
-        runMutableElementsEqualsTests(createSet(), createSet(), createOtherSet())
+        runEqualsTests(createSet(), createOtherSet())
+        runMutableElementsEqualsTests(createSet(), createOtherSet())
     }
 
     @Test
     fun testContains() {
-        runContainsTests(createSet(), createSet(), createSet())
+        runContainsTests(createSet())
         runMutableElementContainsTests(createSet())
     }
 
@@ -46,39 +46,39 @@ class MultiSetImplTest {
 
     @Test
     fun testMinus() {
-        runMinusTests(createSet(), createSet(), createSet(), createSet(), createOtherSet())
+        runMinusTests(createSet(), createOtherSet())
         runMutableElementMinusTests(createSet())
     }
 
     @Test
     fun testPlus() {
-        runPlusTests(createSet(), createSet(), createSet(), createSet(), createOtherSet())
+        runPlusTests(createSet(), createOtherSet())
         runMutableElementPlusTests(createSet())
     }
 
     @Test
     fun testIntersect() {
-        runIntersectTests(createSet(), createSet(), createSet(), createOtherSet())
+        runIntersectTests(createSet(), createOtherSet())
         runMutableElementIntersectTests(createSet())
     }
 
-    @Test fun testIsEmpty() = runIsEmptyTests(createSet(), createSet())
+    @Test fun testIsEmpty() = runIsEmptyTests(createSet())
 
     @Test
     fun testGetCountOf() {
-        runGetCountOfTests(createSet(), createSet())
+        runGetCountOfTests(createSet())
         runMutableElementGetCountOfTests(createSet())
     }
 
     @Test
     fun testIterator() {
-        runIteratorTests(createSet(), createSet())
+        runIteratorTests(createSet())
         runMutableElementsIteratorTests(createSet())
     }
 
     @Test
     fun testToString() {
-        runToStringTests(createSet(), createSet())
+        runToStringTests(createSet())
         runMutableElementToStringTests(createSet())
     }
 }

--- a/kotlin-utils/src/test/kotlin/xyz/lbres/kotlinutils/set/multiset/impl/MultiSetImplTest.kt
+++ b/kotlin-utils/src/test/kotlin/xyz/lbres/kotlinutils/set/multiset/impl/MultiSetImplTest.kt
@@ -7,9 +7,6 @@ import xyz.lbres.kotlinutils.set.multiset.testutils.* // ktlint-disable no-wildc
 import kotlin.test.Test
 
 class MultiSetImplTest {
-    private fun <T> createSet(): (Collection<T>) -> MultiSetImpl<T> = { MultiSetImpl(it) }
-    private fun <T> createOtherSet(): (Collection<T>) -> ConstMutableMultiSetImpl<T> = { ConstMutableMultiSetImpl(it) }
-
     @Test
     fun testConstructor() {
         fun <T> runTest(map: Map<String, Any>) {
@@ -28,57 +25,57 @@ class MultiSetImplTest {
 
     @Test
     fun testEquals() {
-        runEqualsTests(createSet(), createOtherSet())
-        runMutableElementsEqualsTests(createSet(), createOtherSet())
+        runEqualsTests(::MultiSetImpl, ::ConstMutableMultiSetImpl)
+        runMutableElementsEqualsTests(::MultiSetImpl, ::ConstMutableMultiSetImpl)
     }
 
     @Test
     fun testContains() {
-        runContainsTests(createSet())
-        runMutableElementContainsTests(createSet())
+        runContainsTests(::MultiSetImpl)
+        runMutableElementContainsTests(::MultiSetImpl)
     }
 
     @Test
     fun testContainsAll() {
-        runContainsAllTests(createSet())
-        runMutableElementContainsAllTests(createSet())
+        runContainsAllTests(::MultiSetImpl)
+        runMutableElementContainsAllTests(::MultiSetImpl)
     }
 
     @Test
     fun testMinus() {
-        runMinusTests(createSet(), createOtherSet())
-        runMutableElementMinusTests(createSet())
+        runMinusTests(::MultiSetImpl, ::ConstMutableMultiSetImpl)
+        runMutableElementMinusTests(::MultiSetImpl)
     }
 
     @Test
     fun testPlus() {
-        runPlusTests(createSet(), createOtherSet())
-        runMutableElementPlusTests(createSet())
+        runPlusTests(::MultiSetImpl, ::ConstMutableMultiSetImpl)
+        runMutableElementPlusTests(::MultiSetImpl)
     }
 
     @Test
     fun testIntersect() {
-        runIntersectTests(createSet(), createOtherSet())
-        runMutableElementIntersectTests(createSet())
+        runIntersectTests(::MultiSetImpl, ::ConstMutableMultiSetImpl)
+        runMutableElementIntersectTests(::MultiSetImpl)
     }
 
-    @Test fun testIsEmpty() = runIsEmptyTests(createSet())
+    @Test fun testIsEmpty() = runIsEmptyTests(::MultiSetImpl)
 
     @Test
     fun testGetCountOf() {
-        runGetCountOfTests(createSet())
-        runMutableElementGetCountOfTests(createSet())
+        runGetCountOfTests(::MultiSetImpl)
+        runMutableElementGetCountOfTests(::MultiSetImpl)
     }
 
     @Test
     fun testIterator() {
-        runIteratorTests(createSet())
-        runMutableElementsIteratorTests(createSet())
+        runIteratorTests(::MultiSetImpl)
+        runMutableElementsIteratorTests(::MultiSetImpl)
     }
 
     @Test
     fun testToString() {
-        runToStringTests(createSet())
-        runMutableElementToStringTests(createSet())
+        runToStringTests(::MultiSetImpl)
+        runMutableElementToStringTests(::MultiSetImpl)
     }
 }

--- a/kotlin-utils/src/test/kotlin/xyz/lbres/kotlinutils/set/multiset/impl/MutableMultiSetImplTest.kt
+++ b/kotlin-utils/src/test/kotlin/xyz/lbres/kotlinutils/set/multiset/impl/MutableMultiSetImplTest.kt
@@ -7,9 +7,6 @@ import xyz.lbres.kotlinutils.set.multiset.testutils.* // ktlint-disable no-wildc
 import kotlin.test.Test
 
 class MutableMultiSetImplTest {
-    private fun <T> createSet(): (Collection<T>) -> MutableMultiSetImpl<T> = { MutableMultiSetImpl(it) }
-    private fun <T> createOtherSet(): (Collection<T>) -> ConstMultiSetImpl<T> = { ConstMultiSetImpl(it) }
-
     @Test
     fun testConstructor() {
         fun <T> runTest(map: Map<String, Any>) {
@@ -28,23 +25,23 @@ class MutableMultiSetImplTest {
 
     @Test
     fun testEquals() {
-        runMutableEqualsTests(createSet(), createOtherSet())
-        runMutableElementsEqualsTests(createSet(), createOtherSet())
+        runMutableEqualsTests(::MutableMultiSetImpl, ::ConstMultiSetImpl)
+        runMutableElementsEqualsTests(::MutableMultiSetImpl, ::ConstMultiSetImpl)
     }
 
     @Test
     fun testContains() {
-        runMutableContainsTests(createSet())
-        runMutableElementContainsTests(createSet())
+        runMutableContainsTests(::MutableMultiSetImpl)
+        runMutableElementContainsTests(::MutableMultiSetImpl)
     }
 
     @Test
     fun testContainsAll() {
-        runMutableContainsAllTests(createSet())
-        runMutableElementContainsAllTests(createSet())
+        runMutableContainsAllTests(::MutableMultiSetImpl)
+        runMutableElementContainsAllTests(::MutableMultiSetImpl)
     }
 
-    @Test fun testClear() = runClearTests(createSet())
+    @Test fun testClear() = runClearTests(::MutableMultiSetImpl)
     @Test fun testAdd() = runMutableElementsAddTests()
     @Test fun testAddAll() = runMutableElementsAddAllTests()
     @Test fun testRemove() = runMutableElementsRemoveTests()
@@ -53,39 +50,39 @@ class MutableMultiSetImplTest {
 
     @Test
     fun testMinus() {
-        runMinusTests(createSet(), createOtherSet())
-        runMutableElementMinusTests(createSet())
+        runMinusTests(::MutableMultiSetImpl, ::ConstMultiSetImpl)
+        runMutableElementMinusTests(::MutableMultiSetImpl)
     }
 
     @Test
     fun testPlus() {
-        runPlusTests(createSet(), createOtherSet())
-        runMutableElementPlusTests(createSet())
+        runPlusTests(::MutableMultiSetImpl, ::ConstMultiSetImpl)
+        runMutableElementPlusTests(::MutableMultiSetImpl)
     }
 
     @Test
     fun testIntersect() {
-        runIntersectTests(createSet(), createOtherSet())
-        runMutableElementIntersectTests(createSet())
+        runIntersectTests(::MutableMultiSetImpl, ::ConstMultiSetImpl)
+        runMutableElementIntersectTests(::MutableMultiSetImpl)
     }
 
-    @Test fun testIsEmpty() = runMutableIsEmptyTests(createSet())
+    @Test fun testIsEmpty() = runMutableIsEmptyTests(::MutableMultiSetImpl)
 
     @Test
     fun testGetCountOf() {
-        runMutableGetCountOfTests(createSet())
-        runMutableElementGetCountOfTests(createSet())
+        runMutableGetCountOfTests(::MutableMultiSetImpl)
+        runMutableElementGetCountOfTests(::MutableMultiSetImpl)
     }
 
     @Test
     fun testIterator() {
-        runMutableIteratorTests(createSet())
-        runMutableElementsIteratorTests(createSet())
+        runMutableIteratorTests(::MutableMultiSetImpl)
+        runMutableElementsIteratorTests(::MutableMultiSetImpl)
     }
 
     @Test
     fun testToString() {
-        runMutableToStringTests(createSet())
-        runMutableElementToStringTests(createSet())
+        runMutableToStringTests(::MutableMultiSetImpl)
+        runMutableElementToStringTests(::MutableMultiSetImpl)
     }
 }

--- a/kotlin-utils/src/test/kotlin/xyz/lbres/kotlinutils/set/multiset/impl/MutableMultiSetImplTest.kt
+++ b/kotlin-utils/src/test/kotlin/xyz/lbres/kotlinutils/set/multiset/impl/MutableMultiSetImplTest.kt
@@ -28,13 +28,13 @@ class MutableMultiSetImplTest {
 
     @Test
     fun testEquals() {
-        runMutableEqualsTests(createSet(), createSet(), createSet(), createOtherSet())
-        runMutableElementsEqualsTests(createSet(), createSet(), createOtherSet())
+        runMutableEqualsTests(createSet(), createOtherSet())
+        runMutableElementsEqualsTests(createSet(), createOtherSet())
     }
 
     @Test
     fun testContains() {
-        runMutableContainsTests(createSet(), createSet(), createSet())
+        runMutableContainsTests(createSet())
         runMutableElementContainsTests(createSet())
     }
 
@@ -53,39 +53,39 @@ class MutableMultiSetImplTest {
 
     @Test
     fun testMinus() {
-        runMinusTests(createSet(), createSet(), createSet(), createSet(), createOtherSet())
+        runMinusTests(createSet(), createOtherSet())
         runMutableElementMinusTests(createSet())
     }
 
     @Test
     fun testPlus() {
-        runPlusTests(createSet(), createSet(), createSet(), createSet(), createOtherSet())
+        runPlusTests(createSet(), createOtherSet())
         runMutableElementPlusTests(createSet())
     }
 
     @Test
     fun testIntersect() {
-        runIntersectTests(createSet(), createSet(), createSet(), createOtherSet())
+        runIntersectTests(createSet(), createOtherSet())
         runMutableElementIntersectTests(createSet())
     }
 
-    @Test fun testIsEmpty() = runMutableIsEmptyTests(createSet(), createSet())
+    @Test fun testIsEmpty() = runMutableIsEmptyTests(createSet())
 
     @Test
     fun testGetCountOf() {
-        runMutableGetCountOfTests(createSet(), createSet())
+        runMutableGetCountOfTests(createSet())
         runMutableElementGetCountOfTests(createSet())
     }
 
     @Test
     fun testIterator() {
-        runMutableIteratorTests(createSet(), createSet())
+        runMutableIteratorTests(createSet())
         runMutableElementsIteratorTests(createSet())
     }
 
     @Test
     fun testToString() {
-        runMutableToStringTests(createSet(), createSet())
+        runMutableToStringTests(createSet())
         runMutableElementToStringTests(createSet())
     }
 }

--- a/kotlin-utils/src/test/kotlin/xyz/lbres/kotlinutils/set/multiset/impl/mutateTests.kt
+++ b/kotlin-utils/src/test/kotlin/xyz/lbres/kotlinutils/set/multiset/impl/mutateTests.kt
@@ -8,7 +8,7 @@ import kotlin.test.assertEquals
 private fun <T> createSet(): (Collection<T>) -> MutableMultiSetImpl<T> = { MutableMultiSetImpl(it) }
 
 fun runMutableElementsAddTests() {
-    runAddTests(createSet(), createSet())
+    runAddTests(createSet())
 
     // mutable elements
     val listSet: MutableMultiSet<List<String>> = mutableMultiSetOf(listOf("hello", "world"), listOf("farewell", "goodbye"), listOf("goodbye"))

--- a/kotlin-utils/src/test/kotlin/xyz/lbres/kotlinutils/set/multiset/impl/mutateTests.kt
+++ b/kotlin-utils/src/test/kotlin/xyz/lbres/kotlinutils/set/multiset/impl/mutateTests.kt
@@ -5,10 +5,8 @@ import xyz.lbres.kotlinutils.set.multiset.* // ktlint-disable no-wildcard-import
 import xyz.lbres.kotlinutils.set.multiset.testutils.* // ktlint-disable no-wildcard-imports no-unused-imports
 import kotlin.test.assertEquals
 
-private fun <T> createSet(): (Collection<T>) -> MutableMultiSetImpl<T> = { MutableMultiSetImpl(it) }
-
 fun runMutableElementsAddTests() {
-    runAddTests(createSet())
+    runAddTests(::MutableMultiSetImpl)
 
     // mutable elements
     val listSet: MutableMultiSet<List<String>> = mutableMultiSetOf(listOf("hello", "world"), listOf("farewell", "goodbye"), listOf("goodbye"))
@@ -22,7 +20,7 @@ fun runMutableElementsAddTests() {
 }
 
 fun runMutableElementsAddAllTests() {
-    runAddAllTests(createSet())
+    runAddAllTests(::MutableMultiSetImpl)
 
     // mutable elements
     val mutableList1 = mutableListOf("goodbye")
@@ -39,7 +37,7 @@ fun runMutableElementsAddAllTests() {
 }
 
 fun runMutableElementsRemoveTests() {
-    runRemoveTests(createSet())
+    runRemoveTests(::MutableMultiSetImpl)
 
     // mutable elements
     val mutableList = mutableListOf("goodbye")
@@ -57,7 +55,7 @@ fun runMutableElementsRemoveTests() {
 }
 
 fun runMutableElementsRemoveAllTests() {
-    runRemoveAllTests(createSet())
+    runRemoveAllTests(::MutableMultiSetImpl)
 
     // mutable elements
     val mutableList = mutableListOf("goodbye")
@@ -79,7 +77,7 @@ fun runMutableElementsRemoveAllTests() {
 }
 
 fun runMutableElementsRetainAllTests() {
-    runRetainAllTests(createSet())
+    runRetainAllTests(::MutableMultiSetImpl)
 
     // mutable elements
     val mutableList = mutableListOf(1, 4)

--- a/kotlin-utils/src/test/kotlin/xyz/lbres/kotlinutils/set/multiset/testutils/commonContainsTests.kt
+++ b/kotlin-utils/src/test/kotlin/xyz/lbres/kotlinutils/set/multiset/testutils/commonContainsTests.kt
@@ -6,11 +6,11 @@ import xyz.lbres.kotlinutils.set.multiset.MutableMultiSet
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
-fun runContainsTests(
-    createIntSet: (Collection<Int>) -> MultiSet<Int>,
-    createIntListSet: (Collection<IntList>) -> MultiSet<IntList>,
-    createExceptionSet: (Collection<Exception>) -> MultiSet<Exception>,
-) {
+fun runContainsTests(createSet: (Collection<*>) -> MultiSet<*>) {
+    val createIntSet = getCreateSet<Int>(createSet)
+    val createIntListSet = getCreateSet<IntList>(createSet)
+    val createExceptionSet = getCreateSet<Exception>(createSet)
+
     var intSet: MultiSet<Int> = createIntSet(emptyList())
     assertFalse(intSet.contains(0))
     assertFalse(intSet.contains(1000))
@@ -108,13 +108,10 @@ fun runContainsAllTests(createIntSet: (Collection<Int>) -> MultiSet<Int>) {
     assertFalse(set2.containsAll(set1))
 }
 
-fun runMutableContainsTests(
-    createMutableIntSet: (Collection<Int>) -> MutableMultiSet<Int>,
-    createMutableIntListSet: (Collection<IntList>) -> MutableMultiSet<IntList>,
-    createMutableExceptionSet: (Collection<Exception>) -> MutableMultiSet<Exception>,
-) {
-    runContainsTests(createMutableIntSet, createMutableIntListSet, createMutableExceptionSet)
+fun runMutableContainsTests(createMutableSet: (Collection<*>) -> MutableMultiSet<*>) {
+    runContainsTests(createMutableSet)
 
+    val createMutableIntSet = getCreateMutableSet<Int>(createMutableSet)
     val set = createMutableIntSet(emptyList())
     set.add(1)
     assertTrue(set.contains(1))

--- a/kotlin-utils/src/test/kotlin/xyz/lbres/kotlinutils/set/multiset/testutils/commonEqualsTests.kt
+++ b/kotlin-utils/src/test/kotlin/xyz/lbres/kotlinutils/set/multiset/testutils/commonEqualsTests.kt
@@ -8,7 +8,7 @@ import kotlin.test.assertEquals
 import kotlin.test.assertNotEquals
 
 @Suppress(Suppressions.UNCHECKED_CAST)
-fun runEqualsTests( createSet: (Collection<*>) -> MultiSet<*>, createOtherSet: (Collection<*>) -> MultiSet<*>) {
+fun runEqualsTests(createSet: (Collection<*>) -> MultiSet<*>, createOtherSet: (Collection<*>) -> MultiSet<*>) {
     val createIntSet = getCreateSet<Int>(createSet)
     val createStringSet = getCreateSet<String>(createSet)
     val createIntListSet = getCreateSet<IntList>(createSet)

--- a/kotlin-utils/src/test/kotlin/xyz/lbres/kotlinutils/set/multiset/testutils/commonEqualsTests.kt
+++ b/kotlin-utils/src/test/kotlin/xyz/lbres/kotlinutils/set/multiset/testutils/commonEqualsTests.kt
@@ -8,12 +8,12 @@ import kotlin.test.assertEquals
 import kotlin.test.assertNotEquals
 
 @Suppress(Suppressions.UNCHECKED_CAST)
-fun runEqualsTests(
-    createIntSet: (Collection<Int>) -> MultiSet<Int>,
-    createIntListSet: (Collection<IntList>) -> MultiSet<IntList>,
-    createStringSet: (Collection<String>) -> MultiSet<String>,
-    createOtherIntSet: (Collection<Int>) -> MultiSet<Int>
-) {
+fun runEqualsTests( createSet: (Collection<*>) -> MultiSet<*>, createOtherSet: (Collection<*>) -> MultiSet<*>) {
+    val createIntSet = getCreateSet<Int>(createSet)
+    val createStringSet = getCreateSet<String>(createSet)
+    val createIntListSet = getCreateSet<IntList>(createSet)
+    val createOtherIntSet = getCreateSet<Int>(createOtherSet)
+
     // equal
     var set1: MultiSet<Int> = createIntSet(emptyList())
     assertEquals(set1, set1)
@@ -75,14 +75,10 @@ fun runEqualsTests(
     assertNotEquals(anySet1, anySet2)
 }
 
-fun runMutableEqualsTests(
-    createMutableIntSet: (Collection<Int>) -> MutableMultiSet<Int>,
-    createMutableIntListSet: (Collection<IntList>) -> MutableMultiSet<IntList>,
-    createMutableStringSet: (Collection<String>) -> MutableMultiSet<String>,
-    createOtherIntSet: (Collection<Int>) -> MultiSet<Int>
-) {
-    runEqualsTests(createMutableIntSet, createMutableIntListSet, createMutableStringSet, createOtherIntSet)
+fun runMutableEqualsTests(createMutableSet: (Collection<*>) -> MutableMultiSet<*>, createOtherSet: (Collection<*>) -> MultiSet<*>) {
+    runEqualsTests(createMutableSet, createOtherSet)
 
+    val createMutableIntSet = getCreateMutableSet<Int>(createMutableSet)
     val intSet1 = createMutableIntSet(listOf(1, 2, 3, 4, 5, 6))
     val intSet2 = createMutableIntSet(listOf(1, 2, 3, 4, 5, 6))
     assertEquals(intSet1, intSet2)
@@ -101,11 +97,11 @@ fun runMutableEqualsTests(
     assertNotEquals(intSet2, intSet1)
 }
 
-fun runMutableElementsEqualsTests(
-    createIntListSet: (Collection<IntList>) -> MultiSet<IntList>,
-    createIntSetSet: (Collection<Set<Int>>) -> MultiSet<Set<Int>>,
-    createOtherIntSetSet: (Collection<Set<Int>>) -> MultiSet<Set<Int>>,
-) {
+fun runMutableElementsEqualsTests(createSet: (Collection<*>) -> MultiSet<*>, createOtherSet: (Collection<*>) -> MultiSet<*>) {
+    val createIntListSet = getCreateSet<IntList>(createSet)
+    val createIntSetSet = getCreateSet<Set<Int>>(createSet)
+    val createOtherIntSetSet = getCreateSet<Set<Int>>(createOtherSet)
+
     val mutableList1 = mutableListOf(1, 2, 3)
     val mutableList2 = mutableListOf(0, 5, 7)
     val mutableList3 = mutableListOf(0, 5, 7)

--- a/kotlin-utils/src/test/kotlin/xyz/lbres/kotlinutils/set/multiset/testutils/commonIntersectTests.kt
+++ b/kotlin-utils/src/test/kotlin/xyz/lbres/kotlinutils/set/multiset/testutils/commonIntersectTests.kt
@@ -13,12 +13,12 @@ private val e1 = ArithmeticException()
 private val e2 = NullPointerException()
 private val e3 = IllegalArgumentException()
 
-fun runIntersectTests(
-    createIntSet: (Collection<Int>) -> MultiSet<Int>,
-    createIntListSet: (Collection<IntList>) -> MultiSet<IntList>,
-    createExceptionSet: (Collection<Exception>) -> MultiSet<Exception>,
-    createOtherIntSet: (Collection<Int>) -> MultiSet<Int>
-) {
+fun runIntersectTests(createSet: (Collection<*>) -> MultiSet<*>, createOtherSet: (Collection<*>) -> MultiSet<*>) {
+    val createIntSet = getCreateSet<Int>(createSet)
+    val createIntListSet = getCreateSet<IntList>(createSet)
+    val createExceptionSet = getCreateSet<Exception>(createSet)
+    val createOtherIntSet = getCreateSet<Int>(createOtherSet)
+
     // empty
     var intSet1 = createIntSet(emptyList())
     var intSet2 = createIntSet(emptyList())

--- a/kotlin-utils/src/test/kotlin/xyz/lbres/kotlinutils/set/multiset/testutils/commonIteratorTests.kt
+++ b/kotlin-utils/src/test/kotlin/xyz/lbres/kotlinutils/set/multiset/testutils/commonIteratorTests.kt
@@ -7,10 +7,10 @@ import xyz.lbres.kotlinutils.set.multiset.MutableMultiSet
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
-fun runIteratorTests(
-    createIntSet: (Collection<Int>) -> MultiSet<Int>,
-    createIntListSet: (Collection<IntList>) -> MultiSet<IntList>
-) {
+fun runIteratorTests(createSet: (Collection<*>) -> MultiSet<*>) {
+    val createIntSet = getCreateSet<Int>(createSet)
+    val createIntListSet = getCreateSet<IntList>(createSet)
+
     var intSet: MultiSet<Int> = createIntSet(emptyList())
     var intIter = intSet.iterator()
     assertFalse(intIter.hasNext())
@@ -43,12 +43,10 @@ fun runIteratorTests(
     assertTrue(listValues.elementsEqual(listExpected))
 }
 
-fun runMutableIteratorTests(
-    createMutableIntSet: (Collection<Int>) -> MutableMultiSet<Int>,
-    createMutableIntListSet: (Collection<IntList>) -> MutableMultiSet<IntList>
-) {
-    runIteratorTests(createMutableIntSet, createMutableIntListSet)
+fun runMutableIteratorTests(createMutableSet: (Collection<*>) -> MutableMultiSet<*>) {
+    runIteratorTests(createMutableSet)
 
+    val createMutableIntSet = getCreateMutableSet<Int>(createMutableSet)
     val intSet = createMutableIntSet(listOf(1, 2, 3, 4, 1, 4, 5))
     var intIter = intSet.iterator()
     val intValues: MutableList<Int> = mutableListOf()

--- a/kotlin-utils/src/test/kotlin/xyz/lbres/kotlinutils/set/multiset/testutils/commonMinusTests.kt
+++ b/kotlin-utils/src/test/kotlin/xyz/lbres/kotlinutils/set/multiset/testutils/commonMinusTests.kt
@@ -12,13 +12,13 @@ private val e1 = ArithmeticException()
 private val e2 = NullPointerException()
 private val e3 = IllegalArgumentException()
 
-fun runMinusTests(
-    createIntSet: (Collection<Int>) -> MultiSet<Int>,
-    createStringSet: (Collection<String>) -> MultiSet<String>,
-    createExceptionSet: (Collection<Exception>) -> MultiSet<Exception>,
-    createCompListSet: (Collection<List<Comparable<*>>>) -> MultiSet<List<Comparable<*>>>,
-    createOtherIntSet: (Collection<Int>) -> MultiSet<Int>
-) {
+fun runMinusTests(createSet: (Collection<*>) -> MultiSet<*>, createOtherSet: (Collection<*>) -> MultiSet<*>) {
+    val createIntSet = getCreateSet<Int>(createSet)
+    val createStringSet = getCreateSet<String>(createSet)
+    val createExceptionSet = getCreateSet<Exception>(createSet)
+    val createCompListSet = getCreateSet<List<Comparable<*>>>(createSet)
+    val createOtherIntSet = getCreateSet<Int>(createOtherSet)
+
     // empty
     var intSet1 = createIntSet(emptyList())
     var intSet2 = createIntSet(emptyList())

--- a/kotlin-utils/src/test/kotlin/xyz/lbres/kotlinutils/set/multiset/testutils/commonMutateTests.kt
+++ b/kotlin-utils/src/test/kotlin/xyz/lbres/kotlinutils/set/multiset/testutils/commonMutateTests.kt
@@ -6,7 +6,10 @@ import xyz.lbres.kotlinutils.set.multiset.emptyMultiSet
 import xyz.lbres.kotlinutils.set.multiset.multiSetOf
 import kotlin.test.assertEquals
 
-fun runAddTests(createMutableIntSet: (Collection<Int>) -> MutableMultiSet<Int>, createMutableStringListSet: (Collection<StringList>) -> MutableMultiSet<StringList>) {
+fun runAddTests(createMutableSet: (Collection<*>) -> MutableMultiSet<*>) {
+    val createMutableIntSet = getCreateMutableSet<Int>(createMutableSet)
+    val createMutableStringListSet = getCreateMutableSet<StringList>(createMutableSet)
+
     var intSet: MutableMultiSet<Int> = createMutableIntSet(emptyList())
 
     var intExpected = multiSetOf(1)

--- a/kotlin-utils/src/test/kotlin/xyz/lbres/kotlinutils/set/multiset/testutils/commonPlusTests.kt
+++ b/kotlin-utils/src/test/kotlin/xyz/lbres/kotlinutils/set/multiset/testutils/commonPlusTests.kt
@@ -12,13 +12,13 @@ private val e1 = ArithmeticException()
 private val e2 = NullPointerException()
 private val e3 = IllegalArgumentException()
 
-fun runPlusTests(
-    createIntSet: (Collection<Int>) -> MultiSet<Int>,
-    createStringSet: (Collection<String>) -> MultiSet<String>,
-    createExceptionSet: (Collection<Exception>) -> MultiSet<Exception>,
-    createCompListSet: (Collection<List<Comparable<*>>>) -> MultiSet<List<Comparable<*>>>,
-    createOtherIntSet: (Collection<Int>) -> MultiSet<Int>
-) {
+fun runPlusTests(createSet: (Collection<*>) -> MultiSet<*>, createOtherSet: (Collection<*>) -> MultiSet<*>) {
+    val createIntSet = getCreateSet<Int>(createSet)
+    val createStringSet = getCreateSet<String>(createSet)
+    val createExceptionSet = getCreateSet<Exception>(createSet)
+    val createCompListSet = getCreateSet<List<Comparable<*>>>(createSet)
+    val createOtherIntSet = getCreateSet<Int>(createOtherSet)
+
     // empty
     var intSet1: MultiSet<Int> = createIntSet(emptyList())
     var intSet2: MultiSet<Int> = createIntSet(emptyList())

--- a/kotlin-utils/src/test/kotlin/xyz/lbres/kotlinutils/set/multiset/testutils/commonStringTests.kt
+++ b/kotlin-utils/src/test/kotlin/xyz/lbres/kotlinutils/set/multiset/testutils/commonStringTests.kt
@@ -6,10 +6,10 @@ import xyz.lbres.kotlinutils.set.multiset.MutableMultiSet
 import kotlin.test.assertContains
 import kotlin.test.assertEquals
 
-fun runToStringTests(
-    createIntSet: (Collection<Int>) -> MultiSet<Int>,
-    createIntListSet: (Collection<IntList>) -> MultiSet<IntList>
-) {
+fun runToStringTests(createSet: (Collection<*>) -> MultiSet<*>) {
+    val createIntSet = getCreateSet<Int>(createSet)
+    val createIntListSet = getCreateSet<IntList>(createSet)
+
     var intSet: MultiSet<Int> = createIntSet(emptyList())
     var expected = "[]"
     assertEquals(expected, intSet.toString())
@@ -32,12 +32,10 @@ fun runToStringTests(
     assertContains(options, listSet.toString())
 }
 
-fun runMutableToStringTests(
-    createMutableIntSet: (Collection<Int>) -> MutableMultiSet<Int>,
-    createMutableIntListSet: (Collection<IntList>) -> MutableMultiSet<IntList>
-) {
-    runToStringTests(createMutableIntSet, createMutableIntListSet)
+fun runMutableToStringTests(createMutableSet: (Collection<*>) -> MutableMultiSet<*>) {
+    runToStringTests(createMutableSet)
 
+    val createMutableIntSet = getCreateMutableSet<Int>(createMutableSet)
     val set = createMutableIntSet(listOf(2, 2, 4))
     var options = setOf("[2, 2, 4]", "[2, 4, 2]", "[4, 2, 2]")
     assertContains(options, set.toString())

--- a/kotlin-utils/src/test/kotlin/xyz/lbres/kotlinutils/set/multiset/testutils/commonUnaryTests.kt
+++ b/kotlin-utils/src/test/kotlin/xyz/lbres/kotlinutils/set/multiset/testutils/commonUnaryTests.kt
@@ -96,9 +96,7 @@ fun runMutableGetCountOfTests(createMutableSet: (Collection<*>) -> MutableMultiS
     assertEquals(0, set.getCountOf(5))
 }
 
-fun runMutableElementGetCountOfTests(createSet: (Collection<*>) -> MultiSet<*>) {
-    val createIntListSet = getCreateSet<IntList>(createSet)
-
+fun runMutableElementGetCountOfTests(createIntListSet: (List<IntList>) -> MultiSet<List<Int>>) {
     val mutableList1 = mutableListOf(1, 2, 3)
     val mutableList2 = mutableListOf(1, 2, 3)
     val listSet: MultiSet<IntList> = createIntListSet(listOf(mutableList1, mutableList2))

--- a/kotlin-utils/src/test/kotlin/xyz/lbres/kotlinutils/set/multiset/testutils/commonUnaryTests.kt
+++ b/kotlin-utils/src/test/kotlin/xyz/lbres/kotlinutils/set/multiset/testutils/commonUnaryTests.kt
@@ -7,10 +7,10 @@ import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
-fun runIsEmptyTests(
-    createIntSet: (Collection<Int>) -> MultiSet<Int>,
-    createStringSet: (Collection<String>) -> MultiSet<String>
-) {
+fun runIsEmptyTests(createSet: (Collection<*>) -> MultiSet<*>) {
+    val createIntSet = getCreateSet<Int>(createSet)
+    val createStringSet = getCreateSet<String>(createSet)
+
     // empty
     var intSet: MultiSet<Int> = createIntSet(emptyList())
     assertTrue(intSet.isEmpty())
@@ -35,10 +35,10 @@ fun runIsEmptyTests(
     assertFalse(stringSet.isEmpty())
 }
 
-fun runGetCountOfTests(
-    createIntSet: (Collection<Int>) -> MultiSet<Int>,
-    createIntListSet: (Collection<IntList>) -> MultiSet<IntList>
-) {
+fun runGetCountOfTests(createSet: (Collection<*>) -> MultiSet<*>) {
+    val createIntSet = getCreateSet<Int>(createSet)
+    val createIntListSet = getCreateSet<IntList>(createSet)
+
     var intSet: MultiSet<Int> = createIntSet(emptyList())
     assertEquals(0, intSet.getCountOf(0))
     assertEquals(0, intSet.getCountOf(100))
@@ -58,12 +58,10 @@ fun runGetCountOfTests(
     assertEquals(0, listSet.getCountOf(listOf(1, 2)))
 }
 
-fun runMutableIsEmptyTests(
-    createMutableIntSet: (Collection<Int>) -> MutableMultiSet<Int>,
-    createMutableStringSet: (Collection<String>) -> MutableMultiSet<String>
-) {
-    runIsEmptyTests(createMutableIntSet, createMutableStringSet)
+fun runMutableIsEmptyTests(createMutableSet: (Collection<*>) -> MutableMultiSet<*>) {
+    runIsEmptyTests(createMutableSet)
 
+    val createMutableIntSet = getCreateMutableSet<Int>(createMutableSet)
     var intSet = createMutableIntSet(emptyList())
     intSet.remove(1)
     assertTrue(intSet.isEmpty())
@@ -87,12 +85,10 @@ fun runMutableIsEmptyTests(
     assertTrue(intSet.isEmpty())
 }
 
-fun runMutableGetCountOfTests(
-    createMutableIntSet: (Collection<Int>) -> MutableMultiSet<Int>,
-    createMutableIntListSet: (Collection<IntList>) -> MutableMultiSet<IntList>
-) {
-    runGetCountOfTests(createMutableIntSet, createMutableIntListSet)
+fun runMutableGetCountOfTests(createMutableSet: (Collection<*>) -> MutableMultiSet<*>) {
+    runGetCountOfTests(createMutableSet)
 
+    val createMutableIntSet = getCreateMutableSet<Int>(createMutableSet)
     val set = createMutableIntSet(listOf(1, 1, 2, 1, -4, 5, 2))
     set.add(2)
     assertEquals(3, set.getCountOf(2))
@@ -100,7 +96,9 @@ fun runMutableGetCountOfTests(
     assertEquals(0, set.getCountOf(5))
 }
 
-fun runMutableElementGetCountOfTests(createIntListSet: (List<IntList>) -> MultiSet<List<Int>>) {
+fun runMutableElementGetCountOfTests(createSet: (Collection<*>) -> MultiSet<*>) {
+    val createIntListSet = getCreateSet<IntList>(createSet)
+
     val mutableList1 = mutableListOf(1, 2, 3)
     val mutableList2 = mutableListOf(1, 2, 3)
     val listSet: MultiSet<IntList> = createIntListSet(listOf(mutableList1, mutableList2))

--- a/kotlin-utils/src/test/kotlin/xyz/lbres/kotlinutils/set/multiset/testutils/testutils.kt
+++ b/kotlin-utils/src/test/kotlin/xyz/lbres/kotlinutils/set/multiset/testutils/testutils.kt
@@ -41,12 +41,12 @@ fun <T> getCreateSet(genericCreateSet: (Collection<*>) -> MultiSet<*>): (Collect
 /**
  * Convert generic create mutable set function to create mutable set function for a specific type
  *
- * @param genericCreateSet: generic function
+ * @param genericCreateMutableSet: generic function
  * @return type-specific function
  */
-fun <T> getCreateMutableSet(genericCreateSet: (Collection<*>) -> MutableMultiSet<*>): (Collection<T>) -> MutableMultiSet<T> {
+fun <T> getCreateMutableSet(genericCreateMutableSet: (Collection<*>) -> MutableMultiSet<*>): (Collection<T>) -> MutableMultiSet<T> {
     return {
         @Suppress(Suppressions.UNCHECKED_CAST)
-        genericCreateSet(it) as MutableMultiSet<T>
+        genericCreateMutableSet(it) as MutableMultiSet<T>
     }
 }

--- a/kotlin-utils/src/test/kotlin/xyz/lbres/kotlinutils/set/multiset/testutils/testutils.kt
+++ b/kotlin-utils/src/test/kotlin/xyz/lbres/kotlinutils/set/multiset/testutils/testutils.kt
@@ -1,5 +1,6 @@
 package xyz.lbres.kotlinutils.set.multiset.testutils
 
+import xyz.lbres.kotlinutils.internal.constants.Suppressions
 import xyz.lbres.kotlinutils.set.multiset.MultiSet
 import xyz.lbres.kotlinutils.set.multiset.MutableMultiSet
 import kotlin.test.assertEquals
@@ -22,4 +23,30 @@ fun <T> runSingleMutateTest(
     assertEquals(success, result)
     assertEquals(expected, set)
     assertEquals(expected.size, set.size)
+}
+
+/**
+ * Convert generic create set function to create set function for a specific type
+ *
+ * @param genericCreateSet: generic function
+ * @return type-specific function
+ */
+fun <T> getCreateSet(genericCreateSet: (Collection<*>) -> MultiSet<*>): (Collection<T>) -> MultiSet<T> {
+    return {
+        @Suppress(Suppressions.UNCHECKED_CAST)
+        genericCreateSet(it) as MultiSet<T>
+    }
+}
+
+/**
+ * Convert generic create mutable set function to create mutable set function for a specific type
+ *
+ * @param genericCreateSet: generic function
+ * @return type-specific function
+ */
+fun <T> getCreateMutableSet(genericCreateSet: (Collection<*>) -> MutableMultiSet<*>): (Collection<T>) -> MutableMultiSet<T> {
+    return {
+        @Suppress(Suppressions.UNCHECKED_CAST)
+        genericCreateSet(it) as MutableMultiSet<T>
+    }
 }


### PR DESCRIPTION
## What was changed?
- Generic params for createSet in common test helpers

## Checks
- [x] New and existing unit tests pass with my changes
- [ ] Unit tests have been written for all new and changed functions
- [x] Comments have been added where needed
- [x] Docstrings have been updated with any modified function signatures
- [ ] Anything that has been updated for one array type has been updated for *all* array types
  - I know. I'm sorry. It's important.
- [x] ktlint has run successfully
- [ ] The version number has been updated if necessary

## How was this tested?
Existing unit tests
