### PR TITLE
Helper functions in MultiSet tests

### DIFF
--- a/kotlin-utils/src/test/kotlin/xyz/lbres/kotlinutils/set/multiset/inline/filterConsistentTests.kt
+++ b/kotlin-utils/src/test/kotlin/xyz/lbres/kotlinutils/set/multiset/inline/filterConsistentTests.kt
@@ -1,7 +1,12 @@
 package xyz.lbres.kotlinutils.set.multiset.inline
 
+import xyz.lbres.kotlinutils.internal.constants.Suppressions
 import xyz.lbres.kotlinutils.list.IntList
 import xyz.lbres.kotlinutils.set.multiset.* // ktlint-disable no-wildcard-imports no-unused-imports
+import xyz.lbres.kotlinutils.set.multiset.impl.MultiSetImpl
+import xyz.lbres.kotlinutils.set.multiset.testutils.GenericFilterFn
+import xyz.lbres.kotlinutils.set.multiset.testutils.runCommonFilterNotToSetConsistentTests
+import xyz.lbres.kotlinutils.set.multiset.testutils.runCommonFilterToSetConsistentTests
 import kotlin.test.assertContains
 import kotlin.test.assertEquals
 
@@ -141,47 +146,11 @@ fun runFilterNotConsistentTests() {
 }
 
 fun runFilterToSetConsistentTests() {
-    var intSet = emptyMultiSet<Int>()
-    var intExpected = emptyMultiSet<Int>()
-    assertEquals(intExpected, intSet.filterToSetConsistent { true })
-
-    intSet = multiSetOf(1, 1, 1, 2, 3, 4, 5, 5, 6, -1, 0, 0)
-    intExpected = multiSetOf(1, 1, 1, 2, 3, 4, 5, 5, 6, -1, 0, 0)
-    assertEquals(intExpected, intSet.filterToSetConsistent { true })
-
-    intExpected = emptyMultiSet()
-    assertEquals(intExpected, intSet.filterToSetConsistent { false })
-
-    intExpected = multiSetOf(1, 1, 1, 5, 5, 0, 0)
-    assertEquals(intExpected, intSet.filterToSetConsistent { intSet.getCountOf(it) > 1 })
-
-    intExpected = multiSetOf(1, 1, 1, 3, -1, 6)
-    val testInts = setOf(-1, 1, 11, 12, 10, 3, 6, -2)
-    assertEquals(intExpected, intSet.filterToSetConsistent { it in testInts })
-
-    val stringSet = multiSetOf("abc", "abc", "hello", "world", "goodbye", "world", "hi", "world")
-    val stringExpected = multiSetOf("abc", "abc", "hello", "world", "world", "world")
-    assertEquals(stringExpected, stringSet.filterToSetConsistent { it.length in 3..5 })
-
-    val errorSet: MultiSet<Exception> = multiSetOf(e1, e1, e2, e3, e4, e4)
-    val errorExpected: MultiSet<Exception> = multiSetOf(e3, e4, e4)
-    assertEquals(errorExpected, errorSet.filterToSetConsistent { it is ClassCastException })
-
-    // modified
-    intSet = multiSetOf(1, 1, 3, 2, 14, 14)
-    val intOptions = listOf(multiSetOf(1, 1, 2, 14, 14), multiSetOf(3, 2, 14, 14))
-    var previousOdd = false
-    val intPredicate: (Int) -> Boolean = {
-        when {
-            it % 2 == 0 -> true
-            previousOdd -> false
-            else -> {
-                previousOdd = true
-                true
-            }
-        }
+    val filterFn: GenericFilterFn<*> = { set, fn ->
+        @Suppress(Suppressions.UNCHECKED_CAST)
+        set.filterToSetConsistent(fn as (Any?) -> Boolean)
     }
-    assertContains(intOptions, intSet.filterToSetConsistent(intPredicate))
+    runCommonFilterToSetConsistentTests(::MultiSetImpl, filterFn, false)
 
     val mutableList1 = mutableListOf(1, 2, 3)
     val mutableList2 = mutableListOf(0, 5, 7)
@@ -206,47 +175,11 @@ fun runFilterToSetConsistentTests() {
 }
 
 fun runFilterNotToSetConsistentTests() {
-    var intSet = emptyMultiSet<Int>()
-    var intExpected = emptyMultiSet<Int>()
-    assertEquals(intExpected, intSet.filterNotToSetConsistent { true })
-
-    intSet = multiSetOf(1, 1, 1, 2, 3, 4, 5, 5, 6, -1, 0, 0)
-    intExpected = emptyMultiSet()
-    assertEquals(intExpected, intSet.filterNotToSetConsistent { true })
-
-    intExpected = multiSetOf(1, 1, 1, 2, 3, 4, 5, 5, 6, -1, 0, 0)
-    assertEquals(intExpected, intSet.filterNotToSetConsistent { false })
-
-    intExpected = multiSetOf(2, 3, 4, 6, -1)
-    assertEquals(intExpected, intSet.filterNotToSetConsistent { intSet.getCountOf(it) > 1 })
-
-    intExpected = multiSetOf(2, 4, 5, 5, 0, 0)
-    val testInts = setOf(-1, 1, 11, 12, 10, 3, 6, -2)
-    assertEquals(intExpected, intSet.filterNotToSetConsistent { it in testInts })
-
-    val stringSet = multiSetOf("abc", "abc", "hello", "world", "goodbye", "world", "hi", "world")
-    val stringExpected = multiSetOf("goodbye", "hi")
-    assertEquals(stringExpected, stringSet.filterNotToSetConsistent { it.length in 3..5 })
-
-    val errorSet: MultiSet<Exception> = multiSetOf(e1, e1, e2, e3, e4, e4)
-    val errorExpected: MultiSet<Exception> = multiSetOf(e1, e1, e2)
-    assertEquals(errorExpected, errorSet.filterNotToSetConsistent { it is ClassCastException })
-
-    // modified
-    intSet = multiSetOf(1, 1, 3, 2, 14, 14)
-    val intOptions = listOf(multiSetOf(1, 1), multiSetOf(3))
-    var previousOdd = false
-    val intPredicate: (Int) -> Boolean = {
-        when {
-            it % 2 == 0 -> true
-            previousOdd -> false
-            else -> {
-                previousOdd = true
-                true
-            }
-        }
+    val filterFn: GenericFilterFn<*> = { set, fn ->
+        @Suppress(Suppressions.UNCHECKED_CAST)
+        set.filterNotToSetConsistent(fn as (Any?) -> Boolean)
     }
-    assertContains(intOptions, intSet.filterNotToSetConsistent(intPredicate))
+    runCommonFilterNotToSetConsistentTests(::MultiSetImpl, filterFn, false)
 
     val mutableList1 = mutableListOf(1, 2, 3)
     val mutableList2 = mutableListOf(0, 5, 7)

--- a/kotlin-utils/src/test/kotlin/xyz/lbres/kotlinutils/set/multiset/inline/filterConsistentTests.kt
+++ b/kotlin-utils/src/test/kotlin/xyz/lbres/kotlinutils/set/multiset/inline/filterConsistentTests.kt
@@ -4,7 +4,6 @@ import xyz.lbres.kotlinutils.internal.constants.Suppressions
 import xyz.lbres.kotlinutils.list.IntList
 import xyz.lbres.kotlinutils.set.multiset.* // ktlint-disable no-wildcard-imports no-unused-imports
 import xyz.lbres.kotlinutils.set.multiset.impl.MultiSetImpl
-import xyz.lbres.kotlinutils.set.multiset.testutils.GenericFilterFn
 import xyz.lbres.kotlinutils.set.multiset.testutils.runCommonFilterNotToSetConsistentTests
 import xyz.lbres.kotlinutils.set.multiset.testutils.runCommonFilterToSetConsistentTests
 import kotlin.test.assertContains
@@ -146,11 +145,10 @@ fun runFilterNotConsistentTests() {
 }
 
 fun runFilterToSetConsistentTests() {
-    val filterFn: GenericFilterFn<*> = { set, fn ->
+    runCommonFilterToSetConsistentTests(::MultiSetImpl, false) { set, fn ->
         @Suppress(Suppressions.UNCHECKED_CAST)
         set.filterToSetConsistent(fn as (Any?) -> Boolean)
     }
-    runCommonFilterToSetConsistentTests(::MultiSetImpl, filterFn, false)
 
     val mutableList1 = mutableListOf(1, 2, 3)
     val mutableList2 = mutableListOf(0, 5, 7)
@@ -175,11 +173,10 @@ fun runFilterToSetConsistentTests() {
 }
 
 fun runFilterNotToSetConsistentTests() {
-    val filterFn: GenericFilterFn<*> = { set, fn ->
+    runCommonFilterNotToSetConsistentTests(::MultiSetImpl, false) { set, fn ->
         @Suppress(Suppressions.UNCHECKED_CAST)
         set.filterNotToSetConsistent(fn as (Any?) -> Boolean)
     }
-    runCommonFilterNotToSetConsistentTests(::MultiSetImpl, filterFn, false)
 
     val mutableList1 = mutableListOf(1, 2, 3)
     val mutableList2 = mutableListOf(0, 5, 7)

--- a/kotlin-utils/src/test/kotlin/xyz/lbres/kotlinutils/set/multiset/inline/mapConsistentTests.kt
+++ b/kotlin-utils/src/test/kotlin/xyz/lbres/kotlinutils/set/multiset/inline/mapConsistentTests.kt
@@ -11,10 +11,6 @@ import java.lang.NullPointerException
 import kotlin.test.assertContains
 import kotlin.test.assertEquals
 
-private val e1 = NullPointerException("Cannot invoke method on null value")
-private val e2 = ArithmeticException()
-private val e3 = ClassCastException("Cannot cast Int to List")
-
 private val helloWorldMap: (String) -> String = {
     when (it) {
         "hello", "hi" -> "greetings"
@@ -46,13 +42,12 @@ fun runMapConsistentTests() {
     expectedString = listOf("greetings", "planet", "farewell", "planet", "greetings", "greetings", "planet", "leave this planet")
     assertEquals(expectedString.sorted(), stringSet.mapConsistent { helloWorldMap(it) }.sorted())
 
-    var helperString = "1"
+    var prefix = ""
     stringSet = multiSetOf("1", "2", "3", "4", "5")
     expectedString = listOf("11", "112", "1113", "11114", "111115")
     val addingMap: (String) -> String = {
-        val result = "$helperString$it"
-        helperString += "1"
-        result
+        prefix += "1"
+        "$prefix$it"
     }
     assertEquals(expectedString.sorted(), stringSet.mapConsistent { addingMap(it) }.sorted())
 
@@ -63,6 +58,9 @@ fun runMapConsistentTests() {
     expectedInt = listOf(1, 1, 1, 2, 2, 3, 3, 3)
     assertEquals(expectedInt, stringSet.mapConsistent { stringSet.getCountOf(it) }.sorted())
 
+    val e1 = NullPointerException("Cannot invoke method on null value")
+    val e2 = ArithmeticException()
+    val e3 = ClassCastException("Cannot cast Int to List")
     val errorSet = multiSetOf(e1, e2, e3)
     val expectedStringNull = listOf("Cannot cast Int to List", "Cannot invoke method on null value", null)
     assertEquals(expectedStringNull, errorSet.mapConsistent { it.message }.sortedBy { it ?: "null" })

--- a/kotlin-utils/src/test/kotlin/xyz/lbres/kotlinutils/set/multiset/inline/mapConsistentTests.kt
+++ b/kotlin-utils/src/test/kotlin/xyz/lbres/kotlinutils/set/multiset/inline/mapConsistentTests.kt
@@ -1,9 +1,13 @@
 package xyz.lbres.kotlinutils.set.multiset.inline
 
 import xyz.lbres.kotlinutils.general.simpleIf
+import xyz.lbres.kotlinutils.internal.constants.Suppressions
 import xyz.lbres.kotlinutils.list.IntList
 import xyz.lbres.kotlinutils.list.ext.copyWithoutLast
 import xyz.lbres.kotlinutils.set.multiset.* // ktlint-disable no-wildcard-imports no-unused-imports
+import xyz.lbres.kotlinutils.set.multiset.impl.MultiSetImpl
+import xyz.lbres.kotlinutils.set.multiset.testutils.GenericMapFn
+import xyz.lbres.kotlinutils.set.multiset.testutils.runCommonMapToSetConsistentTests
 import java.lang.NullPointerException
 import kotlin.test.assertContains
 import kotlin.test.assertEquals
@@ -115,73 +119,22 @@ fun runMapConsistentTests() {
 }
 
 fun runMapToSetConsistentTests() {
-    var intSet = multiSetOf<Int>()
-    var expectedInt = emptyMultiSet<Int>()
-    assertEquals(expectedInt, intSet.mapToSetConsistent { it * 2 })
-
-    intSet = multiSetOf(1, 1, 5, 7, -3, 0, 2, 5)
-    expectedInt = multiSetOf(-3, 0, 1, 1, 2, 5, 5, 7)
-    assertEquals(expectedInt, intSet.mapToSetConsistent { it })
-
-    expectedInt = multiSetOf(-6, 0, 2, 2, 4, 10, 10, 14)
-    assertEquals(expectedInt, intSet.mapToSetConsistent { it * 2 })
-
-    var expectedString = multiSetOf("-4", "-1", "0", "0", "1", "4", "4", "6")
-    assertEquals(expectedString, intSet.mapToSetConsistent { (it - 1).toString() })
-
-    var stringSet = multiSetOf("hello", "world", "goodbye", "world", "hello", "hi", "world", "wrong")
-    expectedString = multiSetOf("greetings", "planet", "farewell", "planet", "greetings", "greetings", "planet", "leave this planet")
-    assertEquals(expectedString, stringSet.mapToSetConsistent { helloWorldMap(it) })
-
-    var helperString = "1"
-    stringSet = multiSetOf("1", "2", "3", "4", "5")
-    expectedString = multiSetOf("11", "112", "1113", "11114", "111115")
-    val addingMap: (String) -> String = {
-        val result = "$helperString$it"
-        helperString += "1"
-        result
+    val mapFn: GenericMapFn<*, *> = { set, fn ->
+        @Suppress(Suppressions.UNCHECKED_CAST)
+        set.mapToSetConsistent(fn as (Any?) -> Any)
     }
-    assertEquals(expectedString, stringSet.mapToSetConsistent { addingMap(it) })
+    runCommonMapToSetConsistentTests(::MultiSetImpl, mapFn, false)
 
-    expectedString = multiSetOf("", "", "", "", "")
-    assertEquals(expectedString, stringSet.mapToSetConsistent { "" })
-
-    stringSet = multiSetOf("hello", "world", "goodbye", "world", "hello", "hi", "world", "wrong")
-    expectedInt = multiSetOf(1, 1, 1, 2, 2, 3, 3, 3)
-    assertEquals(expectedInt, stringSet.mapToSetConsistent { stringSet.getCountOf(it) })
-
-    val errorSet = multiSetOf(e1, e2, e3)
-    val expectedStringNull = multiSetOf("Cannot cast Int to List", "Cannot invoke method on null value", null)
-    assertEquals(expectedStringNull, errorSet.mapToSetConsistent { it.message })
-
-    var listSet = multiSetOf(listOf(1, 2, 3), listOf(4, 5, 6), emptyList(), listOf(7), listOf(7), listOf(7))
-    val expectedList = multiSetOf(emptyList(), listOf(1, 2), listOf(4, 5), listOf(7), listOf(7), listOf(7))
-    assertEquals(expectedList, listSet.mapToSetConsistent(shortenListMap))
-
-    // modified
-    var modString = ""
-    intSet = multiSetOf(1, 1, 2, 1, 3)
-    val modMap: (Int) -> String = {
-        modString += "1"
-        modString
-    }
-    var resultOptions = listOf(
-        multiSetOf("1", "1", "1", "11", "111"),
-        multiSetOf("1", "11", "11", "11", "111"),
-        multiSetOf("1", "11", "111", "111", "111")
-    )
-    assertContains(resultOptions, intSet.mapToSetConsistent(modMap))
-
-    modString = ""
     val mutableList1 = mutableListOf(1, 2, 3)
     val mutableList2 = mutableListOf(0, 5, 7)
+    var modString = ""
     val modMapList: (IntList) -> String = {
         modString += "1"
         modString
     }
 
-    listSet = multiSetOf(mutableList1, mutableList2, listOf(1, 2, 3))
-    resultOptions = listOf(
+    var listSet = multiSetOf(mutableList1, mutableList2, listOf(1, 2, 3))
+    var resultOptions = listOf(
         multiSetOf("1", "1", "11"),
         multiSetOf("1", "11", "11")
     )

--- a/kotlin-utils/src/test/kotlin/xyz/lbres/kotlinutils/set/multiset/inline/mapConsistentTests.kt
+++ b/kotlin-utils/src/test/kotlin/xyz/lbres/kotlinutils/set/multiset/inline/mapConsistentTests.kt
@@ -6,7 +6,6 @@ import xyz.lbres.kotlinutils.list.IntList
 import xyz.lbres.kotlinutils.list.ext.copyWithoutLast
 import xyz.lbres.kotlinutils.set.multiset.* // ktlint-disable no-wildcard-imports no-unused-imports
 import xyz.lbres.kotlinutils.set.multiset.impl.MultiSetImpl
-import xyz.lbres.kotlinutils.set.multiset.testutils.GenericMapFn
 import xyz.lbres.kotlinutils.set.multiset.testutils.runCommonMapToSetConsistentTests
 import java.lang.NullPointerException
 import kotlin.test.assertContains
@@ -119,11 +118,10 @@ fun runMapConsistentTests() {
 }
 
 fun runMapToSetConsistentTests() {
-    val mapFn: GenericMapFn<*, *> = { set, fn ->
+    runCommonMapToSetConsistentTests(::MultiSetImpl, false) { set, fn ->
         @Suppress(Suppressions.UNCHECKED_CAST)
         set.mapToSetConsistent(fn as (Any?) -> Any)
     }
-    runCommonMapToSetConsistentTests(::MultiSetImpl, mapFn, false)
 
     val mutableList1 = mutableListOf(1, 2, 3)
     val mutableList2 = mutableListOf(0, 5, 7)

--- a/kotlin-utils/src/test/kotlin/xyz/lbres/kotlinutils/set/multiset/inline/mapConsistentTests.kt
+++ b/kotlin-utils/src/test/kotlin/xyz/lbres/kotlinutils/set/multiset/inline/mapConsistentTests.kt
@@ -11,18 +11,6 @@ import java.lang.NullPointerException
 import kotlin.test.assertContains
 import kotlin.test.assertEquals
 
-private val helloWorldMap: (String) -> String = {
-    when (it) {
-        "hello", "hi" -> "greetings"
-        "world" -> "planet"
-        "goodbye" -> "farewell"
-        else -> "leave this planet"
-    }
-}
-private val shortenListMap: (IntList) -> IntList = {
-    simpleIf(it.size > 1, { it.copyWithoutLast() }, { it })
-}
-
 fun runMapConsistentTests() {
     var intSet = multiSetOf<Int>()
     var expectedInt = emptyList<Int>()
@@ -40,6 +28,14 @@ fun runMapConsistentTests() {
 
     var stringSet = multiSetOf("hello", "world", "goodbye", "world", "hello", "hi", "world", "wrong")
     expectedString = listOf("greetings", "planet", "farewell", "planet", "greetings", "greetings", "planet", "leave this planet")
+    val helloWorldMap: (String) -> String = {
+        when (it) {
+            "hello", "hi" -> "greetings"
+            "world" -> "planet"
+            "goodbye" -> "farewell"
+            else -> "leave this planet"
+        }
+    }
     assertEquals(expectedString.sorted(), stringSet.mapConsistent { helloWorldMap(it) }.sorted())
 
     var prefix = ""
@@ -67,6 +63,7 @@ fun runMapConsistentTests() {
 
     var listSet = multiSetOf(listOf(1, 2, 3), listOf(4, 5, 6), emptyList(), listOf(7), listOf(7), listOf(7))
     val expectedList = listOf(emptyList(), listOf(1, 2), listOf(4, 5), listOf(7), listOf(7), listOf(7))
+    val shortenListMap: (IntList) -> IntList = { simpleIf(it.size > 1, { it.copyWithoutLast() }, { it }) }
     assertEquals(expectedList, listSet.mapConsistent(shortenListMap).sortedBy { if (it.isEmpty()) 0 else it.first() })
 
     // modified

--- a/kotlin-utils/src/test/kotlin/xyz/lbres/kotlinutils/set/multiset/inline/mapFilterToSetTests.kt
+++ b/kotlin-utils/src/test/kotlin/xyz/lbres/kotlinutils/set/multiset/inline/mapFilterToSetTests.kt
@@ -4,15 +4,16 @@ import xyz.lbres.kotlinutils.internal.constants.Suppressions
 import xyz.lbres.kotlinutils.list.IntList
 import xyz.lbres.kotlinutils.set.multiset.* // ktlint-disable no-wildcard-imports no-unused-imports
 import xyz.lbres.kotlinutils.set.multiset.impl.MultiSetImpl
-import xyz.lbres.kotlinutils.set.multiset.testutils.* // ktlint-disable no-wildcard-imports no-unused-imports
+import xyz.lbres.kotlinutils.set.multiset.testutils.runCommonFilterNotToSetTests
+import xyz.lbres.kotlinutils.set.multiset.testutils.runCommonFilterToSetTests
+import xyz.lbres.kotlinutils.set.multiset.testutils.runCommonMapToSetTests
 import kotlin.test.assertEquals
 
 fun runMapToSetTests() {
-    val mapFn: GenericMapFn<*, *> = { set, fn ->
+    runCommonMapToSetTests(::MultiSetImpl, false) { set, fn ->
         @Suppress(Suppressions.UNCHECKED_CAST)
         set.mapToSet(fn as (Any?) -> Any)
     }
-    runCommonMapToSetTests(::MultiSetImpl, mapFn, false)
 
     // mutable elements
     val mutableList1 = mutableListOf(1, 2, 3)
@@ -27,11 +28,10 @@ fun runMapToSetTests() {
 }
 
 fun runFilterToSetTests() {
-    val filterFn: GenericFilterFn<*> = { set, fn ->
+    runCommonFilterToSetTests(::MultiSetImpl, false) { set, fn ->
         @Suppress(Suppressions.UNCHECKED_CAST)
         set.filterToSet(fn as (Any?) -> Boolean)
     }
-    runCommonFilterToSetTests(::MultiSetImpl, filterFn, false)
 
     val mutableList1 = mutableListOf(1, 2, 3)
     val mutableList2 = mutableListOf(0, 5, 7)
@@ -45,11 +45,10 @@ fun runFilterToSetTests() {
 }
 
 fun runFilterNotToSetTests() {
-    val filterFn: GenericFilterFn<*> = { set, fn ->
+    runCommonFilterNotToSetTests(::MultiSetImpl, false) { set, fn ->
         @Suppress(Suppressions.UNCHECKED_CAST)
         set.filterNotToSet(fn as (Any?) -> Boolean)
     }
-    runCommonFilterNotToSetTests(::MultiSetImpl, filterFn, false)
 
     val mutableList1 = mutableListOf(1, 2, 3)
     val mutableList2 = mutableListOf(0, 5, 7)

--- a/kotlin-utils/src/test/kotlin/xyz/lbres/kotlinutils/set/multiset/inline/mapFilterToSetTests.kt
+++ b/kotlin-utils/src/test/kotlin/xyz/lbres/kotlinutils/set/multiset/inline/mapFilterToSetTests.kt
@@ -1,89 +1,24 @@
 package xyz.lbres.kotlinutils.set.multiset.inline
 
+import xyz.lbres.kotlinutils.internal.constants.Suppressions
 import xyz.lbres.kotlinutils.list.IntList
-import xyz.lbres.kotlinutils.list.ext.copyWithoutLast
 import xyz.lbres.kotlinutils.set.multiset.* // ktlint-disable no-wildcard-imports no-unused-imports
-import kotlin.test.assertContains
+import xyz.lbres.kotlinutils.set.multiset.impl.MultiSetImpl
+import xyz.lbres.kotlinutils.set.multiset.testutils.* // ktlint-disable no-wildcard-imports no-unused-imports
 import kotlin.test.assertEquals
 
-private val e1 = NullPointerException("Cannot invoke method on null value")
-private val e2 = ArithmeticException()
-private val e3 = ClassCastException("Cannot cast Int to List")
-private val e4 = ClassCastException("other message")
-
 fun runMapToSetTests() {
-    var intSet = multiSetOf<Int>()
-    var expectedInt = emptyMultiSet<Int>()
-    assertEquals(expectedInt, intSet.mapToSet { it * 2 })
-
-    intSet = multiSetOf(1, 1, 5, 7, -3, 0, 2, 5)
-    expectedInt = multiSetOf(-3, 0, 1, 1, 2, 5, 5, 7)
-    assertEquals(expectedInt, intSet.mapToSet { it })
-
-    expectedInt = multiSetOf(-6, 0, 2, 2, 4, 10, 10, 14)
-    assertEquals(expectedInt, intSet.mapToSet { it * 2 })
-
-    var expectedString = multiSetOf("-4", "-1", "0", "0", "1", "4", "4", "6")
-    assertEquals(expectedString, intSet.mapToSet { (it - 1).toString() })
-
-    var stringSet = multiSetOf("hello", "world", "goodbye", "world", "hello", "hi", "world", "wrong")
-    val helloWorldMap: (String) -> String = {
-        when (it) {
-            "hello", "hi" -> "greetings"
-            "world" -> "planet"
-            "goodbye" -> "farewell"
-            else -> "leave this planet"
-        }
+    val mapFn: GenericMapFn<*, *> = { set, fn ->
+        @Suppress(Suppressions.UNCHECKED_CAST)
+        set.mapToSet(fn as (Any?) -> Any)
     }
-    expectedString = multiSetOf("greetings", "planet", "farewell", "planet", "greetings", "greetings", "planet", "leave this planet")
-    assertEquals(expectedString, stringSet.mapToSet { helloWorldMap(it) })
+    runCommonMapToSetTests(::MultiSetImpl, mapFn, false)
 
-    var helperString = "1"
-    stringSet = multiSetOf("1", "2", "3", "4", "5")
-    expectedString = multiSetOf("11", "112", "1113", "11114", "111115")
-    val addingMap: (String) -> String = {
-        val result = "$helperString$it"
-        helperString += "1"
-        result
-    }
-    assertEquals(expectedString, stringSet.mapToSet { addingMap(it) })
-
-    expectedString = multiSetOf("", "", "", "", "")
-    assertEquals(expectedString, stringSet.mapToSet { "" })
-
-    stringSet = multiSetOf("hello", "world", "goodbye", "world", "hello", "hi", "world", "wrong")
-    expectedInt = multiSetOf(1, 1, 1, 2, 2, 3, 3, 3)
-    assertEquals(expectedInt, stringSet.mapToSet { stringSet.getCountOf(it) })
-
-    val errorSet = multiSetOf(e1, e2, e3)
-    val expectedStringNull = multiSetOf("Cannot cast Int to List", "Cannot invoke method on null value", null)
-    assertEquals(expectedStringNull, errorSet.mapToSet { it.message })
-
-    var listSet = multiSetOf(listOf(1, 2, 3), listOf(4, 5, 6), emptyList(), listOf(7), listOf(7), listOf(7))
-    val expectedList = multiSetOf(emptyList(), listOf(1, 2), listOf(4, 5), listOf(7), listOf(7), listOf(7))
-    val listMap: (IntList) -> IntList = {
-        if (it.size > 1) {
-            it.copyWithoutLast()
-        } else {
-            it
-        }
-    }
-    assertEquals(expectedList, listSet.mapToSet(listMap))
-
-    // modified
-    var modString = ""
-    intSet = multiSetOf(1, 1, 2, 1, 3)
-    val modMap: (Int) -> String = {
-        modString += "1"
-        modString
-    }
-    expectedString = multiSetOf("1", "11", "111", "1111", "11111")
-    assertEquals(expectedString, intSet.mapToSet(modMap))
-
+    // mutable elements
     val mutableList1 = mutableListOf(1, 2, 3)
     val mutableList2 = mutableListOf(0, 5, 7)
-    listSet = multiSetOf(mutableList1, mutableList2)
-    expectedInt = multiSetOf(3, 3)
+    val listSet = multiSetOf(mutableList1, mutableList2)
+    var expectedInt = multiSetOf(3, 3)
     assertEquals(expectedInt, listSet.mapToSet { it.size })
 
     mutableList1.remove(2)
@@ -92,47 +27,11 @@ fun runMapToSetTests() {
 }
 
 fun runFilterToSetTests() {
-    var intSet = emptyMultiSet<Int>()
-    var intExpected = emptyMultiSet<Int>()
-    assertEquals(intExpected, intSet.filterToSet { true })
-
-    intSet = multiSetOf(1, 1, 1, 2, 3, 4, 5, 5, 6, -1, 0, 0)
-    intExpected = multiSetOf(1, 1, 1, 2, 3, 4, 5, 5, 6, -1, 0, 0)
-    assertEquals(intExpected, intSet.filterToSet { true })
-
-    intExpected = emptyMultiSet()
-    assertEquals(intExpected, intSet.filterToSet { false })
-
-    intExpected = multiSetOf(1, 1, 1, 5, 5, 0, 0)
-    assertEquals(intExpected, intSet.filterToSet { intSet.getCountOf(it) > 1 })
-
-    intExpected = multiSetOf(1, 1, 1, 3, -1, 6)
-    val testInts = setOf(-1, 1, 11, 12, 10, 3, 6, -2)
-    assertEquals(intExpected, intSet.filterToSet { it in testInts })
-
-    val stringSet = multiSetOf("abc", "abc", "hello", "world", "goodbye", "world", "hi", "world")
-    val stringExpected = multiSetOf("abc", "abc", "hello", "world", "world", "world")
-    assertEquals(stringExpected, stringSet.filterToSet { it.length in 3..5 })
-
-    val errorSet: MultiSet<Exception> = multiSetOf(e1, e1, e2, e3, e4, e4)
-    val errorExpected: MultiSet<Exception> = multiSetOf(e3, e4, e4)
-    assertEquals(errorExpected, errorSet.filterToSet { it is ClassCastException })
-
-    // modified
-    intSet = multiSetOf(1, 1, 2, 14, 14)
-    intExpected = multiSetOf(1, 2, 14, 14)
-    var previousOdd = false
-    val intActual = intSet.filterToSet {
-        when {
-            it % 2 == 0 -> true
-            previousOdd -> false
-            else -> {
-                previousOdd = true
-                true
-            }
-        }
+    val filterFn: GenericFilterFn<*> = { set, fn ->
+        @Suppress(Suppressions.UNCHECKED_CAST)
+        set.filterToSet(fn as (Any?) -> Boolean)
     }
-    assertEquals(intExpected, intActual)
+    runCommonFilterToSetTests(::MultiSetImpl, filterFn, false)
 
     val mutableList1 = mutableListOf(1, 2, 3)
     val mutableList2 = mutableListOf(0, 5, 7)
@@ -146,47 +45,11 @@ fun runFilterToSetTests() {
 }
 
 fun runFilterNotToSetTests() {
-    var intSet = emptyMultiSet<Int>()
-    var intExpected = emptyMultiSet<Int>()
-    assertEquals(intExpected, intSet.filterNotToSet { true })
-
-    intSet = multiSetOf(1, 1, 1, 2, 3, 4, 5, 5, 6, -1, 0, 0)
-    intExpected = emptyMultiSet()
-    assertEquals(intExpected, intSet.filterNotToSet { true })
-
-    intExpected = multiSetOf(1, 1, 1, 2, 3, 4, 5, 5, 6, -1, 0, 0)
-    assertEquals(intExpected, intSet.filterNotToSet { false })
-
-    intExpected = multiSetOf(2, 3, 4, 6, -1)
-    assertEquals(intExpected, intSet.filterNotToSet { intSet.getCountOf(it) > 1 })
-
-    intExpected = multiSetOf(2, 4, 5, 5, 0, 0)
-    val testInts = setOf(-1, 1, 11, 12, 10, 3, 6, -2)
-    assertEquals(intExpected, intSet.filterNotToSet { it in testInts })
-
-    val stringSet = multiSetOf("abc", "abc", "hello", "world", "goodbye", "world", "hi", "world")
-    val stringExpected = multiSetOf("goodbye", "hi")
-    assertEquals(stringExpected, stringSet.filterNotToSet { it.length in 3..5 })
-
-    val errorSet: MultiSet<Exception> = multiSetOf(e1, e1, e2, e3, e4, e4)
-    val errorExpected: MultiSet<Exception> = multiSetOf(e1, e1, e2)
-    assertEquals(errorExpected, errorSet.filterNotToSet { it is ClassCastException })
-
-    // modified
-    intSet = multiSetOf(1, 1, 3, 2, 14, 14)
-    val intOptions = listOf(multiSetOf(1, 1), multiSetOf(1, 3))
-    var previousOdd = false
-    val intActual = intSet.filterNotToSet {
-        when {
-            it % 2 == 0 -> true
-            previousOdd -> false
-            else -> {
-                previousOdd = true
-                true
-            }
-        }
+    val filterFn: GenericFilterFn<*> = { set, fn ->
+        @Suppress(Suppressions.UNCHECKED_CAST)
+        set.filterNotToSet(fn as (Any?) -> Boolean)
     }
-    assertContains(intOptions, intActual)
+    runCommonFilterNotToSetTests(::MultiSetImpl, filterFn, false)
 
     val mutableList1 = mutableListOf(1, 2, 3)
     val mutableList2 = mutableListOf(0, 5, 7)

--- a/kotlin-utils/src/test/kotlin/xyz/lbres/kotlinutils/set/multiset/testutils/commonFilterToSetTests.kt
+++ b/kotlin-utils/src/test/kotlin/xyz/lbres/kotlinutils/set/multiset/testutils/commonFilterToSetTests.kt
@@ -8,7 +8,7 @@ import xyz.lbres.kotlinutils.set.multiset.multiSetOf
 import kotlin.test.assertContains
 import kotlin.test.assertEquals
 
-private typealias GenericFilterFn<S> = (MultiSet<S>, (S) -> Boolean) -> MultiSet<S>
+private typealias GenericFilterFn<S> = (set: MultiSet<S>, predicate: (S) -> Boolean) -> MultiSet<S>
 
 private val e1 = NullPointerException("Cannot invoke method on null value")
 private val e2 = ArithmeticException()
@@ -27,8 +27,8 @@ private val oddPredicate: (Int) -> Boolean = {
     }
 }
 
-private fun <S> runSingleTest(set: MultiSet<S>, expected: MultiSet<S>, const: Boolean, genericFilter: GenericFilterFn<*>, filterFn: (S) -> Boolean) {
-    val result = genericFilter(set, filterFn)
+private fun <S> runSingleTest(set: MultiSet<S>, expected: MultiSet<S>, const: Boolean, genericFilter: GenericFilterFn<*>, predicate: (S) -> Boolean) {
+    val result = genericFilter(set, predicate)
     assertEquals(expected, result)
     assertEquals(const, result is ConstMultiSet<*>)
 }

--- a/kotlin-utils/src/test/kotlin/xyz/lbres/kotlinutils/set/multiset/testutils/commonFilterToSetTests.kt
+++ b/kotlin-utils/src/test/kotlin/xyz/lbres/kotlinutils/set/multiset/testutils/commonFilterToSetTests.kt
@@ -8,6 +8,8 @@ import xyz.lbres.kotlinutils.set.multiset.multiSetOf
 import kotlin.test.assertContains
 import kotlin.test.assertEquals
 
+private typealias GenericFilterFn<S> = (MultiSet<S>, (S) -> Boolean) -> MultiSet<S>
+
 private val e1 = NullPointerException("Cannot invoke method on null value")
 private val e2 = ArithmeticException()
 private val e3 = ClassCastException("Cannot cast Int to List")
@@ -31,8 +33,8 @@ private fun <S> runSingleTest(set: MultiSet<S>, expected: MultiSet<S>, const: Bo
     assertEquals(const, result is ConstMultiSet<*>)
 }
 
-fun runCommonFilterToSetTests(createSet: (Collection<*>) -> MultiSet<*>, genericFilter: GenericFilterFn<*>, const: Boolean) {
-    runCommonFilterTests(createSet, genericFilter, const)
+fun runCommonFilterToSetTests(createSet: (Collection<*>) -> MultiSet<*>, const: Boolean, genericFilter: GenericFilterFn<*>) {
+    runCommonFilterTests(createSet, const, genericFilter)
     val createIntSet = getCreateSet<Int>(createSet)
 
     val intSet = createIntSet(listOf(1, 1, 2, 14, 14))
@@ -41,8 +43,8 @@ fun runCommonFilterToSetTests(createSet: (Collection<*>) -> MultiSet<*>, generic
     runSingleTest(intSet, intExpected, const, genericFilter, oddPredicate)
 }
 
-fun runCommonFilterToSetConsistentTests(createSet: (Collection<*>) -> MultiSet<*>, genericFilter: GenericFilterFn<*>, const: Boolean) {
-    runCommonFilterTests(createSet, genericFilter, const)
+fun runCommonFilterToSetConsistentTests(createSet: (Collection<*>) -> MultiSet<*>, const: Boolean, genericFilter: GenericFilterFn<*>) {
+    runCommonFilterTests(createSet, const, genericFilter)
     val createIntSet = getCreateSet<Int>(createSet)
 
     val intSet = createIntSet(listOf(1, 1, 3, 2, 14, 14))
@@ -53,8 +55,8 @@ fun runCommonFilterToSetConsistentTests(createSet: (Collection<*>) -> MultiSet<*
     assertEquals(const, result is ConstMultiSet<*>)
 }
 
-fun runCommonFilterNotToSetTests(createSet: (Collection<*>) -> MultiSet<*>, genericFilterNot: GenericFilterFn<*>, const: Boolean) {
-    runCommonFilterNotTests(createSet, genericFilterNot, const)
+fun runCommonFilterNotToSetTests(createSet: (Collection<*>) -> MultiSet<*>, const: Boolean, genericFilterNot: GenericFilterFn<*>) {
+    runCommonFilterNotTests(createSet, const, genericFilterNot)
     val createIntSet = getCreateSet<Int>(createSet)
 
     val intSet = createIntSet(listOf(1, 1, 3, 2, 14, 14))
@@ -65,8 +67,8 @@ fun runCommonFilterNotToSetTests(createSet: (Collection<*>) -> MultiSet<*>, gene
     assertEquals(const, result is ConstMultiSet<*>)
 }
 
-fun runCommonFilterNotToSetConsistentTests(createSet: (Collection<*>) -> MultiSet<*>, genericFilterNot: GenericFilterFn<*>, const: Boolean) {
-    runCommonFilterNotTests(createSet, genericFilterNot, const)
+fun runCommonFilterNotToSetConsistentTests(createSet: (Collection<*>) -> MultiSet<*>, const: Boolean, genericFilterNot: GenericFilterFn<*>) {
+    runCommonFilterNotTests(createSet, const, genericFilterNot)
     val createIntSet = getCreateSet<Int>(createSet)
     val createIntListSet = getCreateSet<IntList>(createSet)
 
@@ -92,7 +94,7 @@ fun runCommonFilterNotToSetConsistentTests(createSet: (Collection<*>) -> MultiSe
     runSingleTest(listSet, listExpected, const, genericFilterNot, listPredicate)
 }
 
-private fun runCommonFilterTests(createSet: (Collection<*>) -> MultiSet<*>, genericFilter: GenericFilterFn<*>, const: Boolean) {
+private fun runCommonFilterTests(createSet: (Collection<*>) -> MultiSet<*>, const: Boolean, genericFilter: GenericFilterFn<*>) {
     val createIntSet = getCreateSet<Int>(createSet)
     val createStringSet = getCreateSet<String>(createSet)
     val createExceptionSet = getCreateSet<Exception>(createSet)
@@ -124,7 +126,7 @@ private fun runCommonFilterTests(createSet: (Collection<*>) -> MultiSet<*>, gene
     runSingleTest(errorSet, errorExpected, const, genericFilter) { it is ClassCastException }
 }
 
-private fun runCommonFilterNotTests(createSet: (Collection<*>) -> MultiSet<*>, genericFilterNot: GenericFilterFn<*>, const: Boolean) {
+private fun runCommonFilterNotTests(createSet: (Collection<*>) -> MultiSet<*>, const: Boolean, genericFilterNot: GenericFilterFn<*>) {
     val createIntSet = getCreateSet<Int>(createSet)
     val createIntListSet = getCreateSet<IntList>(createSet)
     val createStringSet = getCreateSet<String>(createSet)

--- a/kotlin-utils/src/test/kotlin/xyz/lbres/kotlinutils/set/multiset/testutils/commonFilterToSetTests.kt
+++ b/kotlin-utils/src/test/kotlin/xyz/lbres/kotlinutils/set/multiset/testutils/commonFilterToSetTests.kt
@@ -1,0 +1,162 @@
+package xyz.lbres.kotlinutils.set.multiset.testutils
+
+import xyz.lbres.kotlinutils.list.IntList
+import xyz.lbres.kotlinutils.set.multiset.MultiSet
+import xyz.lbres.kotlinutils.set.multiset.const.ConstMultiSet
+import xyz.lbres.kotlinutils.set.multiset.emptyMultiSet
+import xyz.lbres.kotlinutils.set.multiset.multiSetOf
+import kotlin.test.assertContains
+import kotlin.test.assertEquals
+
+private val e1 = NullPointerException("Cannot invoke method on null value")
+private val e2 = ArithmeticException()
+private val e3 = ClassCastException("Cannot cast Int to List")
+private val e4 = ClassCastException("other message")
+
+private var previousOdd = false
+private val oddPredicate: (Int) -> Boolean = {
+    when {
+        it % 2 == 0 -> true
+        previousOdd -> false
+        else -> {
+            previousOdd = true
+            true
+        }
+    }
+}
+
+private fun <S> runSingleTest(set: MultiSet<S>, expected: MultiSet<S>, const: Boolean, genericFilter: GenericFilterFn<*>, filterFn: (S) -> Boolean) {
+    val result = genericFilter(set, filterFn)
+    assertEquals(expected, result)
+    assertEquals(const, result is ConstMultiSet<*>)
+}
+
+fun runCommonFilterToSetTests(createSet: (Collection<*>) -> MultiSet<*>, genericFilter: GenericFilterFn<*>, const: Boolean) {
+    runCommonFilterTests(createSet, genericFilter, const)
+    val createIntSet = getCreateSet<Int>(createSet)
+
+    val intSet = createIntSet(listOf(1, 1, 2, 14, 14))
+    val intExpected = multiSetOf(1, 2, 14, 14)
+    previousOdd = false
+    runSingleTest(intSet, intExpected, const, genericFilter, oddPredicate)
+}
+
+fun runCommonFilterToSetConsistentTests(createSet: (Collection<*>) -> MultiSet<*>, genericFilter: GenericFilterFn<*>, const: Boolean) {
+    runCommonFilterTests(createSet, genericFilter, const)
+    val createIntSet = getCreateSet<Int>(createSet)
+
+    val intSet = createIntSet(listOf(1, 1, 3, 2, 14, 14))
+    val intOptions = listOf(multiSetOf(1, 1, 2, 14, 14), multiSetOf(3, 2, 14, 14))
+    previousOdd = false
+    val result = genericFilter(intSet, oddPredicate)
+    assertContains(intOptions, result)
+    assertEquals(const, result is ConstMultiSet<*>)
+}
+
+fun runCommonFilterNotToSetTests(createSet: (Collection<*>) -> MultiSet<*>, genericFilterNot: GenericFilterFn<*>, const: Boolean) {
+    runCommonFilterNotTests(createSet, genericFilterNot, const)
+    val createIntSet = getCreateSet<Int>(createSet)
+
+    val intSet = createIntSet(listOf(1, 1, 3, 2, 14, 14))
+    val intOptions = listOf(multiSetOf(1, 1), multiSetOf(1, 3))
+    previousOdd = false
+    val result = genericFilterNot(intSet, oddPredicate)
+    assertContains(intOptions, result)
+    assertEquals(const, result is ConstMultiSet<*>)
+}
+
+fun runCommonFilterNotToSetConsistentTests(createSet: (Collection<*>) -> MultiSet<*>, genericFilterNot: GenericFilterFn<*>, const: Boolean) {
+    runCommonFilterNotTests(createSet, genericFilterNot, const)
+    val createIntSet = getCreateSet<Int>(createSet)
+    val createIntListSet = getCreateSet<IntList>(createSet)
+
+    val intSet = createIntSet(listOf(1, 1, 3, 2, 14, 14))
+    val intOptions = listOf(multiSetOf(1, 1), multiSetOf(3))
+    previousOdd = false
+    val intResult = genericFilterNot(intSet, oddPredicate)
+    assertContains(intOptions, intResult)
+    assertEquals(const, intResult is ConstMultiSet<*>)
+
+    val listSet = createIntListSet(listOf(listOf(1, 2, 3), listOf(0, 5, 7), listOf(1, 2, 3)))
+
+    var previous12 = false
+    val listPredicate: (IntList) -> Boolean = {
+        if (it.containsAll(listOf(1, 2)) && previous12) {
+            false
+        } else {
+            previous12 = true
+            true
+        }
+    }
+    val listExpected: MultiSet<IntList> = emptyMultiSet()
+    runSingleTest(listSet, listExpected, const, genericFilterNot, listPredicate)
+}
+
+private fun runCommonFilterTests(createSet: (Collection<*>) -> MultiSet<*>, genericFilter: GenericFilterFn<*>, const: Boolean) {
+    val createIntSet = getCreateSet<Int>(createSet)
+    val createStringSet = getCreateSet<String>(createSet)
+    val createExceptionSet = getCreateSet<Exception>(createSet)
+
+    var intSet = createIntSet(emptyList())
+    var intExpected = emptyMultiSet<Int>()
+    runSingleTest(intSet, intExpected, const, genericFilter) { true }
+
+    intSet = createIntSet(listOf(1, 1, 1, 2, 3, 4, 5, 5, 6, -1, 0, 0))
+    intExpected = multiSetOf(1, 1, 1, 2, 3, 4, 5, 5, 6, -1, 0, 0)
+    runSingleTest(intSet, intExpected, const, genericFilter) { true }
+
+    intExpected = emptyMultiSet()
+    runSingleTest(intSet, intExpected, const, genericFilter) { false }
+
+    intExpected = multiSetOf(1, 1, 1, 5, 5, 0, 0)
+    runSingleTest(intSet, intExpected, const, genericFilter) { intSet.getCountOf(it) > 1 }
+
+    intExpected = multiSetOf(1, 1, 1, 3, -1, 6)
+    val testInts = setOf(-1, 1, 11, 12, 10, 3, 6, -2)
+    runSingleTest(intSet, intExpected, const, genericFilter) { it in testInts }
+
+    val stringSet = createStringSet(listOf("abc", "abc", "hello", "world", "goodbye", "world", "hi", "world"))
+    val stringExpected = multiSetOf("abc", "abc", "hello", "world", "world", "world")
+    runSingleTest(stringSet, stringExpected, const, genericFilter) { it.length in 3..5 }
+
+    val errorSet: MultiSet<Exception> = createExceptionSet(listOf(e1, e1, e2, e3, e4, e4))
+    val errorExpected: MultiSet<Exception> = multiSetOf(e3, e4, e4)
+    runSingleTest(errorSet, errorExpected, const, genericFilter) { it is ClassCastException }
+}
+
+private fun runCommonFilterNotTests(createSet: (Collection<*>) -> MultiSet<*>, genericFilterNot: GenericFilterFn<*>, const: Boolean) {
+    val createIntSet = getCreateSet<Int>(createSet)
+    val createIntListSet = getCreateSet<IntList>(createSet)
+    val createStringSet = getCreateSet<String>(createSet)
+    val createExceptionSet = getCreateSet<Exception>(createSet)
+
+    var intSet = createIntSet(emptyList())
+    var intExpected = emptyMultiSet<Int>()
+    runSingleTest(intSet, intExpected, const, genericFilterNot) { true }
+
+    intSet = createIntSet(listOf(1, 1, 1, 2, 3, 4, 5, 5, 6, -1, 0, 0))
+    intExpected = emptyMultiSet()
+    runSingleTest(intSet, intExpected, const, genericFilterNot) { true }
+
+    intExpected = createIntSet(listOf(1, 1, 1, 2, 3, 4, 5, 5, 6, -1, 0, 0))
+    runSingleTest(intSet, intExpected, const, genericFilterNot) { false }
+
+    intExpected = createIntSet(listOf(2, 3, 4, 6, -1))
+    runSingleTest(intSet, intExpected, const, genericFilterNot) { intSet.getCountOf(it) > 1 }
+
+    intExpected = createIntSet(listOf(2, 4, 5, 5, 0, 0))
+    val testInts = setOf(-1, 1, 11, 12, 10, 3, 6, -2)
+    runSingleTest(intSet, intExpected, const, genericFilterNot) { it in testInts }
+
+    val stringSet = createStringSet(listOf("abc", "abc", "hello", "world", "goodbye", "world", "hi", "world"))
+    val stringExpected = multiSetOf("goodbye", "hi")
+    runSingleTest(stringSet, stringExpected, const, genericFilterNot) { it.length in 3..5 }
+
+    val errorSet = createExceptionSet(listOf(e1, e1, e2, e3, e4, e4))
+    val errorExpected: MultiSet<Exception> = multiSetOf(e1, e1, e2)
+    runSingleTest(errorSet, errorExpected, const, genericFilterNot) { it is ClassCastException }
+
+    val listSet = createIntListSet(listOf(listOf(1, 2, 3), listOf(0, 5, 6)))
+    val listExpected = multiSetOf(listOf(1, 2, 3))
+    runSingleTest(listSet, listExpected, const, genericFilterNot) { it.contains(0) }
+}

--- a/kotlin-utils/src/test/kotlin/xyz/lbres/kotlinutils/set/multiset/testutils/commonMapToSetTests.kt
+++ b/kotlin-utils/src/test/kotlin/xyz/lbres/kotlinutils/set/multiset/testutils/commonMapToSetTests.kt
@@ -1,0 +1,113 @@
+package xyz.lbres.kotlinutils.set.multiset.testutils
+
+import xyz.lbres.kotlinutils.general.simpleIf
+import xyz.lbres.kotlinutils.list.IntList
+import xyz.lbres.kotlinutils.list.ext.copyWithoutLast
+import xyz.lbres.kotlinutils.set.multiset.MultiSet
+import xyz.lbres.kotlinutils.set.multiset.const.ConstMultiSet
+import xyz.lbres.kotlinutils.set.multiset.emptyMultiSet
+import xyz.lbres.kotlinutils.set.multiset.multiSetOf
+import kotlin.test.assertContains
+import kotlin.test.assertEquals
+
+private val e1 = NullPointerException("Cannot invoke method on null value")
+private val e2 = ArithmeticException()
+private val e3 = ClassCastException("Cannot cast Int to List")
+
+private var modString = ""
+private val modMap: (Int) -> String = {
+    modString += "1"
+    modString
+}
+
+private fun <S, T> runSingleTest(set: MultiSet<S>, expected: MultiSet<T>, const: Boolean, genericMap: GenericMapFn<*, *>, mapFn: (S) -> T) {
+    val result = genericMap(set, mapFn)
+    assertEquals(expected, result)
+    assertEquals(const, result is ConstMultiSet<*>)
+}
+
+fun runCommonMapToSetTests(createSet: (Collection<*>) -> MultiSet<*>, genericMap: GenericMapFn<*, *>, const: Boolean) {
+    runCommonTests(createSet, genericMap, const)
+    val createIntSet = getCreateSet<Int>(createSet)
+
+    modString = ""
+    val intSet = createIntSet(listOf(1, 1, 2, 1, 3))
+    val expectedString = multiSetOf("1", "11", "111", "1111", "11111")
+    runSingleTest(intSet, expectedString, const, genericMap, modMap)
+}
+
+fun runCommonMapToSetConsistentTests(createSet: (Collection<*>) -> MultiSet<*>, genericMap: GenericMapFn<*, *>, const: Boolean) {
+    runCommonTests(createSet, genericMap, const)
+    val createIntSet = getCreateSet<Int>(createSet)
+
+    modString = ""
+    val intSet = createIntSet(listOf(1, 1, 2, 1, 3))
+    val resultOptions = listOf(
+        multiSetOf("1", "1", "1", "11", "111"),
+        multiSetOf("1", "11", "11", "11", "111"),
+        multiSetOf("1", "11", "111", "111", "111")
+    )
+    val result = genericMap(intSet, modMap)
+    assertContains(resultOptions, result)
+    assertEquals(const, result is ConstMultiSet<*>)
+}
+
+private fun runCommonTests(createSet: (Collection<*>) -> MultiSet<*>, genericMap: GenericMapFn<*, *>, const: Boolean) {
+    val createIntSet = getCreateSet<Int>(createSet)
+    val createStringSet = getCreateSet<String>(createSet)
+    val createIntListSet = getCreateSet<IntList>(createSet)
+    val createExceptionSet = getCreateSet<Exception>(createSet)
+
+    var intSet = createIntSet(emptyList())
+    var expectedInt = emptyMultiSet<Int>()
+    runSingleTest(intSet, expectedInt, const, genericMap) { it * 2 }
+
+    intSet = createIntSet(listOf(1, 1, 5, 7, -3, 0, 2, 5))
+    expectedInt = multiSetOf(-3, 0, 1, 1, 2, 5, 5, 7)
+    runSingleTest(intSet, expectedInt, const, genericMap) { it }
+
+    expectedInt = multiSetOf(-6, 0, 2, 2, 4, 10, 10, 14)
+    runSingleTest(intSet, expectedInt, const, genericMap) { it * 2 }
+
+    var expectedString = multiSetOf("-4", "-1", "0", "0", "1", "4", "4", "6")
+    runSingleTest(intSet, expectedString, const, genericMap) { (it - 1).toString() }
+
+    var stringSet = createStringSet(listOf("hello", "world", "goodbye", "world", "hello", "hi", "world", "wrong"))
+    expectedString = multiSetOf("greetings", "planet", "farewell", "planet", "greetings", "greetings", "planet", "leave this planet")
+    val helloWorldMap: (String) -> String = {
+        when (it) {
+            "hello", "hi" -> "greetings"
+            "world" -> "planet"
+            "goodbye" -> "farewell"
+            else -> "leave this planet"
+        }
+    }
+    runSingleTest(stringSet, expectedString, const, genericMap, helloWorldMap)
+
+    var helperString = "1"
+    stringSet = createStringSet(listOf("1", "2", "3", "4", "5"))
+    expectedString = multiSetOf("11", "112", "1113", "11114", "111115")
+    val addingMap: (String) -> String = {
+        val result = "$helperString$it"
+        helperString += "1"
+        result
+    }
+    runSingleTest(stringSet, expectedString, const, genericMap, addingMap)
+
+    expectedString = multiSetOf("", "", "", "", "")
+    runSingleTest(stringSet, expectedString, const, genericMap) { "" }
+
+    stringSet = createStringSet(listOf("hello", "world", "goodbye", "world", "hello", "hi", "world", "wrong"))
+    expectedInt = multiSetOf(1, 1, 1, 2, 2, 3, 3, 3)
+    runSingleTest(stringSet, expectedInt, const, genericMap) { stringSet.getCountOf(it) }
+
+    val errorSet = createExceptionSet(listOf(e1, e2, e3))
+    val expectedStringNull = multiSetOf("Cannot cast Int to List", "Cannot invoke method on null value", null)
+    runSingleTest(errorSet, expectedStringNull, const, genericMap) { it.message }
+
+    val listSet = createIntListSet(listOf(listOf(1, 2, 3), listOf(4, 5, 6), emptyList(), listOf(7), listOf(7), listOf(7)))
+    val expectedList = multiSetOf(emptyList(), listOf(1, 2), listOf(4, 5), listOf(7), listOf(7), listOf(7))
+    runSingleTest(listSet, expectedList, const, genericMap) {
+        simpleIf(it.size > 1, { it.copyWithoutLast() }, { it })
+    }
+}

--- a/kotlin-utils/src/test/kotlin/xyz/lbres/kotlinutils/set/multiset/testutils/commonMapToSetTests.kt
+++ b/kotlin-utils/src/test/kotlin/xyz/lbres/kotlinutils/set/multiset/testutils/commonMapToSetTests.kt
@@ -10,6 +10,8 @@ import xyz.lbres.kotlinutils.set.multiset.multiSetOf
 import kotlin.test.assertContains
 import kotlin.test.assertEquals
 
+private typealias GenericMapFn<S, T> = (MultiSet<S>, (S) -> T) -> MultiSet<T>
+
 private val e1 = NullPointerException("Cannot invoke method on null value")
 private val e2 = ArithmeticException()
 private val e3 = ClassCastException("Cannot cast Int to List")
@@ -26,8 +28,8 @@ private fun <S, T> runSingleTest(set: MultiSet<S>, expected: MultiSet<T>, const:
     assertEquals(const, result is ConstMultiSet<*>)
 }
 
-fun runCommonMapToSetTests(createSet: (Collection<*>) -> MultiSet<*>, genericMap: GenericMapFn<*, *>, const: Boolean) {
-    runCommonTests(createSet, genericMap, const)
+fun runCommonMapToSetTests(createSet: (Collection<*>) -> MultiSet<*>, const: Boolean, genericMap: GenericMapFn<*, *>) {
+    runCommonTests(createSet, const, genericMap)
     val createIntSet = getCreateSet<Int>(createSet)
 
     modString = ""
@@ -36,8 +38,8 @@ fun runCommonMapToSetTests(createSet: (Collection<*>) -> MultiSet<*>, genericMap
     runSingleTest(intSet, expectedString, const, genericMap, modMap)
 }
 
-fun runCommonMapToSetConsistentTests(createSet: (Collection<*>) -> MultiSet<*>, genericMap: GenericMapFn<*, *>, const: Boolean) {
-    runCommonTests(createSet, genericMap, const)
+fun runCommonMapToSetConsistentTests(createSet: (Collection<*>) -> MultiSet<*>, const: Boolean, genericMap: GenericMapFn<*, *>) {
+    runCommonTests(createSet, const, genericMap)
     val createIntSet = getCreateSet<Int>(createSet)
 
     modString = ""
@@ -52,7 +54,7 @@ fun runCommonMapToSetConsistentTests(createSet: (Collection<*>) -> MultiSet<*>, 
     assertEquals(const, result is ConstMultiSet<*>)
 }
 
-private fun runCommonTests(createSet: (Collection<*>) -> MultiSet<*>, genericMap: GenericMapFn<*, *>, const: Boolean) {
+private fun runCommonTests(createSet: (Collection<*>) -> MultiSet<*>, const: Boolean, genericMap: GenericMapFn<*, *>) {
     val createIntSet = getCreateSet<Int>(createSet)
     val createStringSet = getCreateSet<String>(createSet)
     val createIntListSet = getCreateSet<IntList>(createSet)

--- a/kotlin-utils/src/test/kotlin/xyz/lbres/kotlinutils/set/multiset/testutils/commonMapToSetTests.kt
+++ b/kotlin-utils/src/test/kotlin/xyz/lbres/kotlinutils/set/multiset/testutils/commonMapToSetTests.kt
@@ -10,11 +10,7 @@ import xyz.lbres.kotlinutils.set.multiset.multiSetOf
 import kotlin.test.assertContains
 import kotlin.test.assertEquals
 
-private typealias GenericMapFn<S, T> = (MultiSet<S>, (S) -> T) -> MultiSet<T>
-
-private val e1 = NullPointerException("Cannot invoke method on null value")
-private val e2 = ArithmeticException()
-private val e3 = ClassCastException("Cannot cast Int to List")
+private typealias GenericMapFn<S, T> = (set: MultiSet<S>, transform: (S) -> T) -> MultiSet<T>
 
 private var modString = ""
 private val modMap: (Int) -> String = {
@@ -22,8 +18,8 @@ private val modMap: (Int) -> String = {
     modString
 }
 
-private fun <S, T> runSingleTest(set: MultiSet<S>, expected: MultiSet<T>, const: Boolean, genericMap: GenericMapFn<*, *>, mapFn: (S) -> T) {
-    val result = genericMap(set, mapFn)
+private fun <S, T> runSingleTest(set: MultiSet<S>, expected: MultiSet<T>, const: Boolean, genericMap: GenericMapFn<*, *>, transform: (S) -> T) {
+    val result = genericMap(set, transform)
     assertEquals(expected, result)
     assertEquals(const, result is ConstMultiSet<*>)
 }
@@ -86,13 +82,12 @@ private fun runCommonTests(createSet: (Collection<*>) -> MultiSet<*>, const: Boo
     }
     runSingleTest(stringSet, expectedString, const, genericMap, helloWorldMap)
 
-    var helperString = "1"
+    var prefix = ""
     stringSet = createStringSet(listOf("1", "2", "3", "4", "5"))
     expectedString = multiSetOf("11", "112", "1113", "11114", "111115")
     val addingMap: (String) -> String = {
-        val result = "$helperString$it"
-        helperString += "1"
-        result
+        prefix += "1"
+        "$prefix$it"
     }
     runSingleTest(stringSet, expectedString, const, genericMap, addingMap)
 
@@ -103,6 +98,9 @@ private fun runCommonTests(createSet: (Collection<*>) -> MultiSet<*>, const: Boo
     expectedInt = multiSetOf(1, 1, 1, 2, 2, 3, 3, 3)
     runSingleTest(stringSet, expectedInt, const, genericMap) { stringSet.getCountOf(it) }
 
+    val e1 = NullPointerException("Cannot invoke method on null value")
+    val e2 = ArithmeticException()
+    val e3 = ClassCastException("Cannot cast Int to List")
     val errorSet = createExceptionSet(listOf(e1, e2, e3))
     val expectedStringNull = multiSetOf("Cannot cast Int to List", "Cannot invoke method on null value", null)
     runSingleTest(errorSet, expectedStringNull, const, genericMap) { it.message }

--- a/kotlin-utils/src/test/kotlin/xyz/lbres/kotlinutils/set/multiset/testutils/testutils.kt
+++ b/kotlin-utils/src/test/kotlin/xyz/lbres/kotlinutils/set/multiset/testutils/testutils.kt
@@ -5,6 +5,9 @@ import xyz.lbres.kotlinutils.set.multiset.MultiSet
 import xyz.lbres.kotlinutils.set.multiset.MutableMultiSet
 import kotlin.test.assertEquals
 
+typealias GenericFilterFn<S> = (MultiSet<S>, (S) -> Boolean) -> MultiSet<S>
+typealias GenericMapFn<S, T> = (MultiSet<S>, (S) -> T) -> MultiSet<T>
+
 /**
  * Run single test to mutate set
  *

--- a/kotlin-utils/src/test/kotlin/xyz/lbres/kotlinutils/set/multiset/testutils/testutils.kt
+++ b/kotlin-utils/src/test/kotlin/xyz/lbres/kotlinutils/set/multiset/testutils/testutils.kt
@@ -5,9 +5,6 @@ import xyz.lbres.kotlinutils.set.multiset.MultiSet
 import xyz.lbres.kotlinutils.set.multiset.MutableMultiSet
 import kotlin.test.assertEquals
 
-typealias GenericFilterFn<S> = (MultiSet<S>, (S) -> Boolean) -> MultiSet<S>
-typealias GenericMapFn<S, T> = (MultiSet<S>, (S) -> T) -> MultiSet<T>
-
 /**
  * Run single test to mutate set
  *

--- a/kotlin-utils/src/test/kotlin/xyz/lbres/kotlinutils/set/multiset/utils/countsmap/initializationTests.kt
+++ b/kotlin-utils/src/test/kotlin/xyz/lbres/kotlinutils/set/multiset/utils/countsmap/initializationTests.kt
@@ -1,5 +1,6 @@
 package xyz.lbres.kotlinutils.set.multiset.utils.countsmap
 
+import xyz.lbres.kotlinutils.set.multiset.const.constMultiSetOf
 import xyz.lbres.kotlinutils.set.multiset.multiSetOf
 import xyz.lbres.kotlinutils.set.multiset.utils.CountsMap
 import kotlin.test.assertEquals
@@ -28,6 +29,11 @@ fun runFromTests() {
     val listExpected = CountsMap(mapOf(listOf(123) to 1, listOf(1, 4, 5, 6) to 1, listOf(99, 100, 97) to 1))
     val listActual = CountsMap.from(setOf(listOf(123), listOf(1, 4, 5, 6), listOf(99, 100, 97)))
     assertEquals(listExpected, listActual)
+
+    // const multi set
+    intExpected = CountsMap.from(listOf(1, 1, 2, 4, 1, 1, 5, 6, 5))
+    intActual = CountsMap.from(constMultiSetOf(1, 1, 1, 1, 2, 4, 5, 5, 6))
+    assertEquals(intExpected, intActual)
 }
 
 fun runDistinctTests() {


### PR DESCRIPTION
## What was changed?

- Add common helper functions, which will later be shared with const versions of invline methods

## Checks
- [x] New and existing unit tests pass with my changes
- [x] Unit tests have been written for all new and changed functions
- [x] Comments have been added where needed
- [ ] Docstrings have been updated with any modified function signatures
- [ ] Anything that has been updated for one array type has been updated for *all* array types
  - I know. I'm sorry. It's important.
- [x] ktlint has run successfully
- [ ] The version number has been updated if necessary

## How was this tested?
This is the test
